### PR TITLE
#12 - Updated AEM package file names to be:  'asset-share-commons.ui.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- 0012: Updated AEM package file names to be: 'asset-share-commons.ui.apps-<version>' and 'asset-share-commons.ui.content-<version>'.
 - 16: Changed ui.content/pom.xml to remove the core dependency, distribution config, and jslint plug-in.  
 
 ### Added

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -156,6 +156,7 @@
 				<configuration>
 					<name>asset-share-commons.ui.apps</name>
 					<group>asset-share-commons</group>
+					<finalName>asset-share-commons.ui.apps-${project.version}</finalName>
 					<filterSource>src/main/content/META-INF/vault/filter.xml</filterSource>
 					<properties>
 						<acHandling>merge_preserve</acHandling>

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -138,6 +138,7 @@
 				<configuration>
 					<name>asset-share-commons.ui.content</name>
 					<group>asset-share-commons</group>
+					<finalName>asset-share-commons.ui.content-${project.version}</finalName>
 					<filterSource>src/main/content/META-INF/vault/filter.xml</filterSource>
 					<properties>
 						<acHandling>merge_preserve</acHandling>


### PR DESCRIPTION
…apps-<version>' and 'asset-share-commons.ui.content-<version>' via the finalName configuration in the content-package-maven-plugin to filename matches the package name (as installed in AEM).