### PR TITLE
#11 - Skip ui.content deploy by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- 0011: Added skip deploy directive to ui.content pom.xml (as the ui.content artifact does not get deployed to bintray)
 - 16: Changed ui.content/pom.xml to remove the core dependency, distribution config, and jslint plug-in.  
 
 ### Added

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -145,6 +145,14 @@
 					<targetURL>http://${crx.host}:${crx.port}/crx/packmgr/service.jsp</targetURL>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<profiles>


### PR DESCRIPTION
Skips deploy by default when performing mvn releases for this artifact (as we only upload to GitHub releases and not to bintray, as this is sample content).