### PR TITLE
#29 - Marks (ACS Commons) EmailService reference as Dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 0016: Changed ui.content/pom.xml to remove the core dependency, distribution config, and jslint plug-in.  
 - 0018: Updated components to leverage the ASC modelCache for models: Config, AssetModel and PagePredicate. Added HTL Maven Plugin to prevent typos in the HTL.
 - 0027:  XSS Protect user input for Share emails in EmailShareServiceImpl.java
-- 0029: Resolve issue with WARN in logs over missing ACS Commons EmailService dependency. 
 
 ### Fixed
 
+- 0029: Resolve issue with WARN in logs over missing ACS Commons EmailService dependency. 
 - 0053: Fixed issue with broken log in and log out links
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 0012: Updated AEM package file names to be: 'asset-share-commons.ui.apps-<version>' and 'asset-share-commons.ui.content-<version>'.
 - 0016: Changed ui.content/pom.xml to remove the core dependency, distribution config, and jslint plug-in.  
 - 0027:  XSS Protect user input for Share emails in EmailShareServiceImpl.java
+- 0029: Resolve issue with WARN in logs over missing ACS Commons EmailService dependency. 
 
 ### Added
 ### Removed

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
@@ -42,6 +42,7 @@ import org.apache.sling.xss.XSSAPI;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
@@ -68,7 +69,7 @@ public class EmailShareServiceImpl implements ShareService {
 
     private Cfg cfg;
 
-    @Reference
+    @Reference(policy = ReferencePolicy.DYNAMIC)
     private EmailService emailService;
 
     @Reference


### PR DESCRIPTION
This seems to resolve the issues with EmailService not resolving properly. Can someone experiencing the problem verify this? I was able to reproduce (prior to this fix) by:

1) Installing ASC
2) Installing ACS Commons 3.11.0

After explicitly marking this dependency as Dynamic i am unable to reproduce the issues. (ASC EmailShareServiceImpl comes and goes (active/unsatisfied) with the ACS Commons EmailService availability.