### PR TITLE
53 - using incorrect property for login and logout links

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/user-menu.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/user-menu.html
@@ -39,7 +39,7 @@
                         ${currentStyle['greeting']} ${userMenu.userName}
                         <br/>
                         <a class="cmp-user__action"
-                           href="${currentStyle['logOutUrl']}">
+                           href="${currentStyle['logOutLink']}">
                             ${currentStyle['logOutLabel']}
                         </a>
                     </div>
@@ -47,7 +47,7 @@
 
                 <!--/* Anonymous */-->
                 <a class="ui left cmp-user__action"
-                   href="${currentStyle['loginUrl']}"
+                   href="${currentStyle['logInLink']}"
                    data-sly-test="${!loggedIn}">
                     ${currentStyle['logInLabel']}
                 </a>


### PR DESCRIPTION
property names did not match policy dialog property. Fixes #53. 