### PR TITLE
Bugfix/56 single release ui.content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 0016: Changed ui.content/pom.xml to remove the core dependency, distribution config, and jslint plug-in.  
 - 0018: Updated components to leverage the ASC modelCache for models: Config, AssetModel and PagePredicate. Added HTL Maven Plugin to prevent typos in the HTL.
 - 0027: XSS Protect user input for Share emails in EmailShareServiceImpl.java
-- 0056: Updated pom.xml to include ui.content as a module. Updated ui.content/pom.xml so only gets built with profile of 'autoInstallPackage-all' and 'autoInstallPackagePublish-all'
 
 ### Fixed
 
 - 0053: Fixed issue with broken log in and log out links
+- 0056: Updated pom.xml to include ui.content as a module. Updated ui.content/pom.xml so only gets built with profile of 'autoInstallPackage-all' and 'autoInstallPackagePublish-all'
 
 ### Added
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 0012: Updated AEM package file names to be: 'asset-share-commons.ui.apps-<version>' and 'asset-share-commons.ui.content-<version>'.
 - 0016: Changed ui.content/pom.xml to remove the core dependency, distribution config, and jslint plug-in.  
 - 0018: Updated components to leverage the ASC modelCache for models: Config, AssetModel and PagePredicate. Added HTL Maven Plugin to prevent typos in the HTL.
-- 0027:  XSS Protect user input for Share emails in EmailShareServiceImpl.java
+- 0027: XSS Protect user input for Share emails in EmailShareServiceImpl.java
+- 0056: Updated pom.xml to include ui.content as a module. Updated ui.content/pom.xml so only gets built with profile of 'autoInstallPackage-all' and 'autoInstallPackagePublish-all'
 
 ### Fixed
 

--- a/pom.xml
+++ b/pom.xml
@@ -554,6 +554,7 @@
     <modules>
         <module>core</module>
         <module>ui.apps</module>
+        <module>ui.content</module>
     </modules>
     <distributionManagement>
         <repository>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -266,5 +266,30 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>autoInstallPackagePublish-all</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.day.jcr.vault</groupId>
+						<artifactId>content-package-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>install-content-package-publish</id>
+								<phase>install</phase>
+								<goals>
+									<goal>install</goal>
+								</goals>
+								<configuration>
+									<targetURL>http://${publish.crx.host}:${publish.crx.port}/crx/packmgr/service.jsp</targetURL>
+									<userId>${publish.crx.username}</userId>
+									<password>${publish.crx.password}</password>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -158,27 +158,7 @@
 	</build>
 	<profiles>
 		<profile>
-			<id>autoInstallPackage</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>com.day.jcr.vault</groupId>
-						<artifactId>content-package-maven-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>install-content-package</id>
-								<phase>install</phase>
-								<goals>
-									<goal>install</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		<profile>
-			<id>autoInstallPackagePublish</id>
+			<id>autoInstallPackagePublish-all</id>
 			<build>
 				<plugins>
 					<plugin>


### PR DESCRIPTION
- added ui.content to Parent pom.xml modules to fix Issue #56 
- removed autoInstallPackage and autoInstallPackagePublish profiles from ui.content so that it is built but not deployed
- NOTE* ui.content will always be built but not deployed with standard maven profiles. Don't see this as a big issue since most projects will include ui.apps and core directly via a project specific maven pom