### PR TITLE
#80 - Moved predicate component groupIds to be derived from the resou…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
+
+- 0080: Set for Predicate components, update the groupId to be derived from the predicate component resource. 
+
 ### Fixed
 ### Added
 ### Removed

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/AbstractPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/AbstractPredicate.java
@@ -29,7 +29,6 @@ import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
 public abstract class AbstractPredicate implements Predicate {
-    private static final String REQUEST_ATTR_PREDICATE_GROUP_TRACKER = "asset-share-commons__predicate-group";
     private static final String REQUEST_ATTR_FORM_ID_TRACKER = "asset-share-commons__form-id";
 
     @Self
@@ -39,8 +38,6 @@ public abstract class AbstractPredicate implements Predicate {
     @ValueMapValue
     @Default(booleanValues = false)
     private boolean expanded;
-
-    private int group = 1;
 
     private Field coreField;
 
@@ -58,7 +55,7 @@ public abstract class AbstractPredicate implements Predicate {
     }
 
     public String getGroup() {
-        return group + "_group";
+        return getResourceId() + "_group";
     }
 
     public String getInitialValue() {
@@ -71,7 +68,7 @@ public abstract class AbstractPredicate implements Predicate {
 
     public String getId() {
         if (request.getResource() != null) {
-            return getName() + "_" + String.valueOf(request.getResource().getPath().hashCode());
+            return getName() + "_" + getResourceId();
         } else {
             return coreField.getId();
         }
@@ -115,22 +112,9 @@ public abstract class AbstractPredicate implements Predicate {
      */
     protected final void initPredicate(final SlingHttpServletRequest request, final Field coreField) {
         this.coreField = coreField;
-        initGroup(request);
     }
 
-    /**
-     * Initializes the predicate group number from the tracking request attribute, and increments for the next Sling Model calling this method.
-     *
-     * @param request the current SlingHttpServletRequest object.
-     */
-    protected synchronized final void initGroup(final SlingHttpServletRequest request) {
-        /* Track Predicate Groups across Request */
-
-        final Object groupTracker = request.getAttribute(REQUEST_ATTR_PREDICATE_GROUP_TRACKER);
-        if (groupTracker != null && (groupTracker instanceof Integer)) {
-            group = (Integer) groupTracker + 1;
-        }
-
-        request.setAttribute(REQUEST_ATTR_PREDICATE_GROUP_TRACKER, group);
+    private String getResourceId() {
+        return String.valueOf(Math.abs(request.getResource().getPath().hashCode() - 1));
     }
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PagePredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PagePredicate.java
@@ -19,20 +19,42 @@
 
 package com.adobe.aem.commons.assetshare.components.predicates;
 
+import org.apache.sling.api.resource.ValueMap;
+
 import java.util.List;
 import java.util.Map;
 
 public interface PagePredicate extends Predicate {
 
+    /**
+     * @return the QueryBuilder order by property as exposed by the PagePredicate Model.
+     */
     String getOrderBy();
 
+    /**
+     * @return the QueryBuilder order by direction  as exposed by the PagePredicate Model.
+     */
     String getOrderBySort();
 
+    /**
+     * @return the QueryBuilder limit as exposed by the PagePredicate Model.
+     */
     int getLimit();
 
+    /**
+     * @return the QueryBuilder guessTotal as exposed by the PagePredicate Model.
+     */
     String getGuessTotal();
 
+    /**
+     * @return the QueryBuilder paths as exposed by the PagePredicate Model.
+     */
     List<String> getPaths();
 
+    /**
+     * Note that these groups for the PagePredicate are always < 0 to avoid collisions with user provided params.
+     *
+     * @return the QueryBuilder param map that represents the PredicateModel.
+     */
     Map<String, String> getParams();
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PagePredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PagePredicateImpl.java
@@ -22,9 +22,11 @@ package com.adobe.aem.commons.assetshare.components.predicates.impl;
 import com.adobe.aem.commons.assetshare.components.predicates.AbstractPredicate;
 import com.adobe.aem.commons.assetshare.components.predicates.HiddenPredicate;
 import com.adobe.aem.commons.assetshare.components.predicates.PagePredicate;
+import com.adobe.aem.commons.assetshare.components.predicates.Predicate;
 import com.adobe.aem.commons.assetshare.util.ComponentModelVisitor;
 import com.adobe.aem.commons.assetshare.util.PredicateUtil;
 import com.day.cq.dam.api.DamConstants;
+import com.day.cq.search.eval.TypePredicateEvaluator;
 import com.day.cq.wcm.api.Page;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -173,10 +175,10 @@ public class PagePredicateImpl extends AbstractPredicate implements PagePredicat
     }
 
     public Map<String, String> getParams() {
-        int systemGroupId = Integer.MAX_VALUE;
+        int systemGroupId = -1;
         final Map<String, String> params = new HashMap<>();
 
-        params.put("type", DamConstants.NT_DAM_ASSET);
+        params.put(TypePredicateEvaluator.TYPE, DamConstants.NT_DAM_ASSET);
 
         int i = 0;
         final String pathGroup = String.valueOf(systemGroupId--) + "_group";
@@ -190,9 +192,8 @@ public class PagePredicateImpl extends AbstractPredicate implements PagePredicat
             params.putAll(hiddenPredicate.getParams(systemGroupId--));
         }
 
-        params.put("p.limit", String.valueOf(getLimit()));
-        params.put("p.guessTotal", getGuessTotal());
-
+        params.put("p." + com.day.cq.search.Predicate.PARAM_LIMIT, String.valueOf(getLimit()));
+        params.put("p." + com.day.cq.search.Predicate.PARAM_GUESS_TOTAL, getGuessTotal());
 
         return params;
     }


### PR DESCRIPTION
…rce path

The groupId for a predicate component is now the Abs value of the resource path's hash-code (same as AEM Core Form components [1]). This does have the chance of not being unique, though highly unlikely. 

Also updated the PagePredicate to always use negative group id's to avoid collisions.

[1] https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/AbstractFieldImpl.java

/cc @arpithaar @kaushalmall