### PR TITLE
#80 - Set predicate groupId via SlingPostProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
+
+- 0080: Search predicate components now set the predicate group id via a SlingPostProcessor.
+
 ### Fixed
 
 - 0074: Removed unused configurations (originally added for release purposes) from ui.content pom.xml

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/postprocessor/PredicateGroupIdPostProcessor.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/postprocessor/PredicateGroupIdPostProcessor.java
@@ -1,16 +1,15 @@
 package com.adobe.aem.commons.assetshare.components.predicates.impl.postprocessor;
 
+import com.adobe.aem.commons.assetshare.util.impl.AbstractSlingResourceTypeResourceVisitor;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.commons.WCMUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.AbstractResourceVisitor;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.SlingPostProcessor;
 import org.osgi.service.component.annotations.Component;
@@ -24,26 +23,36 @@ import java.util.TreeSet;
 public class PredicateGroupIdPostProcessor implements SlingPostProcessor {
     public static final String PN_GROUP_ID = "predicateGroupId";
     public static final String PN_GENERATE_GROUP_ID = "generatePredicateGroupId";
+
     @Override
     synchronized public void process(final SlingHttpServletRequest request, final List<Modification> list) throws Exception {
 
         Resource resource = request.getResource();
 
-        if (JcrConstants.JCR_CONTENT.equals(resource.getName())
-                || StringUtils.containsNone(resource.getPath(), JcrConstants.JCR_CONTENT)
-                || resource.getValueMap().get(PN_GROUP_ID, Long.class) != null) {
-            // Note a validate candidate resource
+        if (rejectsRequestResource(resource)) {
             return;
         }
 
         final Page currentPage = request.getResourceResolver().adaptTo(PageManager.class).getContainingPage(resource);
-
         final GroupIdVisitor visitor = new GroupIdVisitor();
 
         visitor.accept(currentPage.getContentResource());
 
-        final Collection<Long> groupIds = visitor.getGroupIds();
+        final Long nextGroupId = findNextAvailableGroupId(visitor.getGroupIds());
 
+        final ModifiableValueMap mvm = resource.adaptTo(ModifiableValueMap.class);
+        mvm.put(PN_GROUP_ID, nextGroupId);
+
+        list.add(Modification.onModified(resource.getPath()));
+    }
+
+    private boolean rejectsRequestResource(Resource resource) {
+        return (JcrConstants.JCR_CONTENT.equals(resource.getName())
+                || StringUtils.containsNone(resource.getPath(), JcrConstants.JCR_CONTENT)
+                || resource.getValueMap().get(PN_GROUP_ID, Long.class) != null);
+    }
+
+    private Long findNextAvailableGroupId(Collection<Long> groupIds) {
         Long nextGroupId = null;
         Long count = 1l;
 
@@ -55,29 +64,14 @@ public class PredicateGroupIdPostProcessor implements SlingPostProcessor {
             }
         }
 
-        final ModifiableValueMap mvm = resource.adaptTo(ModifiableValueMap.class);
-        mvm.put(PN_GROUP_ID, nextGroupId);
-
-        list.add(Modification.onModified(resource.getPath()));
+        return nextGroupId;
     }
 
-
-
-    private class GroupIdVisitor extends AbstractResourceVisitor {
+    private class GroupIdVisitor extends AbstractSlingResourceTypeResourceVisitor {
         final Set<Long> groupIds = new TreeSet<>();
 
         public Collection getGroupIds() {
             return groupIds;
-        }
-
-        @Override
-        public final void accept(Resource resource) {
-            final ValueMap properties = resource.getValueMap();
-
-            // Only traverse resources that have a sling:resourceType; those without sling:resourceTypes are not components and simply sub-component configurations resources (such as Option lists)
-            if (properties.get(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, String.class) != null) {
-                super.accept(resource);
-            }
         }
 
         @Override

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/postprocessor/PredicateGroupIdPostProcessor.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/postprocessor/PredicateGroupIdPostProcessor.java
@@ -1,0 +1,101 @@
+package com.adobe.aem.commons.assetshare.components.predicates.impl.postprocessor;
+
+import com.adobe.aem.commons.assetshare.components.predicates.AbstractPredicate;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.commons.WCMUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.AbstractResourceVisitor;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
+import org.apache.sling.servlets.post.Modification;
+import org.apache.sling.servlets.post.SlingPostProcessor;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+@Component(service = SlingPostProcessor.class)
+public class PredicateGroupIdPostProcessor implements SlingPostProcessor {
+    public static final String PN_GROUP_ID = "predicateGroupId";
+    public static final String PN_GENERATE_GROUP_ID = "generateGroupId";
+    @Override
+    synchronized public void process(final SlingHttpServletRequest request, final List<Modification> list) throws Exception {
+
+        Resource resource = request.getResource();
+
+        if (JcrConstants.JCR_CONTENT.equals(resource.getName())
+                || StringUtils.containsNone(resource.getPath(), JcrConstants.JCR_CONTENT)
+                || resource.getValueMap().get(PN_GROUP_ID, Long.class) != null) {
+            // Note a validate candidate resource
+            return;
+        }
+
+        final Page currentPage = request.getResourceResolver().adaptTo(PageManager.class).getContainingPage(resource);
+
+        final GroupIdVisitor visitor = new GroupIdVisitor();
+
+        visitor.accept(currentPage.getContentResource());
+
+        final Collection<Long> groupIds = visitor.getGroupIds();
+
+        Long nextGroupId = null;
+        Long count = 1l;
+
+        while (nextGroupId == null) {
+            if (!groupIds.contains(count)) {
+                nextGroupId = count;
+            } else {
+                count++;
+            }
+        }
+
+        final ModifiableValueMap mvm = resource.adaptTo(ModifiableValueMap.class);
+        mvm.put(PN_GROUP_ID, nextGroupId);
+
+        list.add(Modification.onModified(resource.getPath()));
+    }
+
+
+
+    private class GroupIdVisitor extends AbstractResourceVisitor {
+        final Set<Long> groupIds = new TreeSet<>();
+
+        public Collection getGroupIds() {
+            return groupIds;
+        }
+
+        @Override
+        public final void accept(Resource resource) {
+            final ValueMap properties = resource.getValueMap();
+
+            // Only traverse resources that have a sling:resourceType; those without sling:resourceTypes are not components and simply sub-component configurations resources (such as Option lists)
+            if (properties.get(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, String.class) != null) {
+                super.accept(resource);
+            }
+        }
+
+        @Override
+        protected void visit(final Resource resource) {
+            com.day.cq.wcm.api.components.Component component = WCMUtils.getComponent(resource);
+                if (component.getProperties().get(PN_GENERATE_GROUP_ID, false)) {
+                    final ValueMap properties = resource.getValueMap();
+                    final Long groupId = properties.get(PN_GROUP_ID, Long.class);
+
+                    if (groupId != null) {
+                        groupIds.add(groupId);
+                    }
+                }
+            }
+    }
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/postprocessor/PredicateGroupIdPostProcessor.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/postprocessor/PredicateGroupIdPostProcessor.java
@@ -1,6 +1,5 @@
 package com.adobe.aem.commons.assetshare.components.predicates.impl.postprocessor;
 
-import com.adobe.aem.commons.assetshare.components.predicates.AbstractPredicate;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.commons.WCMUtils;
@@ -14,11 +13,7 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.SlingPostProcessor;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.metatype.annotations.AttributeDefinition;
-import org.osgi.service.metatype.annotations.Designate;
-import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 import java.util.Collection;
 import java.util.List;
@@ -28,7 +23,7 @@ import java.util.TreeSet;
 @Component(service = SlingPostProcessor.class)
 public class PredicateGroupIdPostProcessor implements SlingPostProcessor {
     public static final String PN_GROUP_ID = "predicateGroupId";
-    public static final String PN_GENERATE_GROUP_ID = "generateGroupId";
+    public static final String PN_GENERATE_GROUP_ID = "generatePredicateGroupId";
     @Override
     synchronized public void process(final SlingHttpServletRequest request, final List<Modification> list) throws Exception {
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/ComponentModelVisitor.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/ComponentModelVisitor.java
@@ -1,10 +1,8 @@
 package com.adobe.aem.commons.assetshare.util;
 
+import com.adobe.aem.commons.assetshare.util.impl.AbstractSlingResourceTypeResourceVisitor;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.AbstractResourceVisitor;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.apache.sling.models.factory.ModelFactory;
 
 import java.util.ArrayList;
@@ -17,7 +15,7 @@ import java.util.Collection;
  *
  * @param <T> The Model type to collect.
  */
-public final class ComponentModelVisitor<T> extends AbstractResourceVisitor {
+public final class ComponentModelVisitor<T> extends AbstractSlingResourceTypeResourceVisitor {
     final Collection<T> models = new ArrayList<>();
     final Collection<Resource> resources = new ArrayList<>();
 
@@ -58,18 +56,6 @@ public final class ComponentModelVisitor<T> extends AbstractResourceVisitor {
         return resources;
     }
 
-    @Override
-    /**
-     * {@inheritDoc}
-     **/
-    public final void accept(Resource resource) {
-        final ValueMap properties = resource.getValueMap();
-
-        // Only traverse resources that have a sling:resourceType; those without sling:resourceTypes are not components and simply sub-component configurations resources (such as Option lists)
-        if (properties.get(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, String.class) != null) {
-            super.accept(resource);
-        }
-    }
 
     @Override
     protected final void visit(Resource resource) {

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/AbstractSlingResourceTypeResourceVisitor.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/AbstractSlingResourceTypeResourceVisitor.java
@@ -1,0 +1,22 @@
+package com.adobe.aem.commons.assetshare.util.impl;
+
+import org.apache.sling.api.resource.AbstractResourceVisitor;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
+
+/**
+ * Abstract Resource Visitor that only accepts Resources  that have a sling:resourceType set.
+ */
+public abstract class AbstractSlingResourceTypeResourceVisitor extends AbstractResourceVisitor {
+    @Override
+    public final void accept(Resource resource) {
+        final ValueMap properties = resource.getValueMap();
+
+        // Only traverse resources that have a sling:resourceType; those without sling:resourceTypes are not components and simply sub-component configurations resources (such as Option lists)
+        if (properties.get(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, String.class) != null) {
+            super.accept(resource);
+        }
+    }
+
+}

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/.content.xml
@@ -22,4 +22,5 @@
     jcr:title="Date Range Filter"
     componentGroup="Asset Share Commons - Search"
     cq:icon="calendar"
+    generateGroupId="{Boolean}true"
     jcr:description="Allows a user to filter search results by a date range or relative date range property."/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/.content.xml
@@ -22,5 +22,5 @@
     jcr:title="Date Range Filter"
     componentGroup="Asset Share Commons - Search"
     cq:icon="calendar"
-    generateGroupId="{Boolean}true"
+    generatePredicateGroupId="{Boolean}true"
     jcr:description="Allows a user to filter search results by a date range or relative date range property."/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/.content.xml
@@ -22,5 +22,5 @@
     jcr:title="Property Filter"
     sling:resourceSuperType="core/wcm/components/form/options/v1/options"
     componentGroup="Asset Share Commons - Search"
-    generateGroupId="{Boolean}true"
+    generatePredicateGroupId="{Boolean}true"
     jcr:description="Allows a user to filter search results by a jcr metadata property."/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/.content.xml
@@ -22,4 +22,5 @@
     jcr:title="Property Filter"
     sling:resourceSuperType="core/wcm/components/form/options/v1/options"
     componentGroup="Asset Share Commons - Search"
+    generateGroupId="{Boolean}true"
     jcr:description="Allows a user to filter search results by a jcr metadata property."/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/.content.xml
@@ -23,4 +23,5 @@
     sling:resourceSuperType="asset-share-commons/components/search/property"
     componentGroup="Asset Share Commons - Search"
     cq:icon="tags"
+    generateGroupId="{Boolean}true"
     jcr:description="Allows a user to filter search results based on cq:tags"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/.content.xml
@@ -23,5 +23,5 @@
     sling:resourceSuperType="asset-share-commons/components/search/property"
     componentGroup="Asset Share Commons - Search"
     cq:icon="tags"
-    generateGroupId="{Boolean}true"
+    generatePredicateGroupId="{Boolean}true"
     jcr:description="Allows a user to filter search results based on cq:tags"/>

--- a/ui.content/src/main/content/jcr_root/conf/asset-share-commons/settings/wcm/templates/search-template-dark/initial/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/asset-share-commons/settings/wcm/templates/search-template-dark/initial/.content.xml
@@ -72,6 +72,7 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="TYPE"
                         sling:resourceType="asset-share-commons/components/search/property"
+                        predicateGroupId="{Long}1"
                         operation="equals"
                         property="jcr:content/metadata/dc:format"
                         source="local"
@@ -107,6 +108,7 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="LAST MODIFIED"
                         sling:resourceType="asset-share-commons/components/search/date-range"
+                        predicateGroupId="{Long}2"
                         dateType="relativedaterange"
                         property="jcr:content/jcr:lastModified"
                         type="radio">
@@ -147,6 +149,7 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="STYLE"
                         sling:resourceType="asset-share-commons/components/search/tags"
+                        predicateGroupId="{Long}3"
                         operation="equals"
                         type="slider"/>
                     <tags_1940742412
@@ -158,6 +161,7 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="ORIENTATION"
                         sling:resourceType="asset-share-commons/components/search/tags"
+                        predicateGroupId="{Long}4"
                         operation="equals"
                         type="toggle"/>
                     <hidden

--- a/ui.content/src/main/content/jcr_root/conf/asset-share-commons/settings/wcm/templates/search-template/initial/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/asset-share-commons/settings/wcm/templates/search-template/initial/.content.xml
@@ -72,6 +72,7 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="TYPE"
                         sling:resourceType="asset-share-commons/components/search/property"
+                        predicateGroupId="{Long}1"
                         operation="equals"
                         property="jcr:content/metadata/dc:format"
                         source="local"
@@ -107,6 +108,7 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="LAST MODIFIED"
                         sling:resourceType="asset-share-commons/components/search/date-range"
+                        predicateGroupId="{Long}2"
                         dateType="relativedaterange"
                         property="jcr:content/jcr:lastModified"
                         type="radio">
@@ -133,6 +135,7 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="CREATED"
                         sling:resourceType="asset-share-commons/components/search/date-range"
+                        predicateGroupId="{Long}3"
                         dateType="daterange"
                         endPlaceholder="End Date"
                         property="jcr:created"
@@ -147,6 +150,7 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="STYLE"
                         sling:resourceType="asset-share-commons/components/search/tags"
+                        predicateGroupId="{Long}4"
                         operation="equals"
                         type="slider"/>
                     <tags_1940742412
@@ -158,6 +162,7 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="ORIENTATION"
                         sling:resourceType="asset-share-commons/components/search/tags"
+                        predicateGroupId="{Long}5"
                         operation="equals"
                         type="toggle"/>
                     <hidden


### PR DESCRIPTION
@arpithaar @kaushalmall  - Ok, WDYT about this? 

Its a SlingPostProcessor that writes a new property `predicateGroupId`  (if one does not already exist) for component that have a `cq:Component@generatePredicateGroupId=true`.

It walks the page tree and makes sure the predicateGroupId is unique.

If no `predicateGroupId` exists, it uses the hashcode for the path (though the `predicateGroupId` should always be set on the first component edit) .. this fallback is more for existing ASC impls that might upgrade to this and not edit the predicate components immediately.


UPDATE: Only adjustment i could think of is to have this NOOP immediately if the Page's resourceType doesnt hit some white list. This will traverse all notes under all pages on commits and NOOP on those. A simple fix would be to only allow this to traverse (do "real" work) if the page's RT is of a whitelisted RT (ie. `page.getContentResource().isResourceType(whitelistedRT)`).. i THINK most ppl would have their search page's use the ASC search-page as the superType, so they wouldn't have to change this very often? 

/cc @godanny86 
