### PR TITLE
Feature/80c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - 0074: Removed unused configurations (originally added for release purposes) from ui.content pom.xml
+- 0080: Handle the numbering of predicate search components after insert, and made group numbering mode logical.
 
 ### Added
 - 0090: Added asset-share-commons.cart.clear JavaScript event when cart is cleared

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/AbstractPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/AbstractPredicate.java
@@ -20,7 +20,6 @@
 package com.adobe.aem.commons.assetshare.components.predicates;
 
 import com.adobe.cq.wcm.core.components.models.form.Field;
-import com.day.cq.wcm.api.components.ComponentContext;
 import com.day.cq.wcm.commons.WCMUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -29,14 +28,13 @@ import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.Required;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
-import org.osgi.service.component.annotations.Component;
 
 public abstract class AbstractPredicate implements Predicate {
     private static final String REQUEST_ATTR_PREDICATE_GROUP_TRACKER = "asset-share-commons__predicate-group";
     private static final String REQUEST_ATTR_LEGACY_PREDICATE_GROUP_TRACKER = "asset-share-commons__legacy_predicate-group";
 
     private static final String REQUEST_ATTR_FORM_ID_TRACKER = "asset-share-commons__form-id";
-    private static final String PN_GENERATE_PREDICATE_ID = "generatePredicateId";
+    private static final String PN_GENERATE_PREDICATE_GROUP_ID = "generatePredicateGroupId";
 
     private static final Integer INITIAL_GROUP_ID = 0;
     private static final Integer INITIAL_LEGACY_GROUP_ID = 10000 - 1;
@@ -134,35 +132,60 @@ public abstract class AbstractPredicate implements Predicate {
      */
     protected synchronized final void initGroup(final SlingHttpServletRequest request) {
         /* Track Predicate Groups across Request */
+
+        if (!isGroupIdGeneratingComponent(request) || !generateGroupId(request)) {
+            generateLegacyGroupId(request);
+        }
+    }
+
+    /**
+     * @param request the Sling Http Request object.
+     * @return true if the component is marked as generating a predicate group Id.
+     */
+    private boolean isGroupIdGeneratingComponent(SlingHttpServletRequest request) {
         final com.day.cq.wcm.api.components.Component component = WCMUtils.getComponent(request.getResource());
+        return component != null && component.getProperties().get(PN_GENERATE_PREDICATE_GROUP_ID, false);
+    }
 
-        boolean generatedPredicateId = false;
-        if (component != null && component.getProperties().get(PN_GENERATE_PREDICATE_ID, false)) {
+    /**
+     * Set the groupId and set the request attribute.
+     *
+     * @param request the Sling Http Request object.
+     * @return true if a group id was generated.
+     */
+    private boolean generateGroupId(SlingHttpServletRequest request) {
+        Object groupTracker = request.getAttribute(REQUEST_ATTR_PREDICATE_GROUP_TRACKER);
 
-            Object groupTracker = request.getAttribute(REQUEST_ATTR_PREDICATE_GROUP_TRACKER);
-            if (groupTracker == null) {
-                groupTracker = INITIAL_GROUP_ID;
-            }
-
-            if (groupTracker instanceof Integer) {
-                group = (Integer) groupTracker + 1;
-                request.setAttribute(REQUEST_ATTR_PREDICATE_GROUP_TRACKER, group);
-                generatedPredicateId = true;
-            }
+        if (groupTracker == null) {
+            groupTracker = INITIAL_GROUP_ID;
         }
 
-        if (!generatedPredicateId) {
-            Object legacyGroupTracker = request.getAttribute(REQUEST_ATTR_LEGACY_PREDICATE_GROUP_TRACKER);
-            if (legacyGroupTracker == null) {
-                legacyGroupTracker = INITIAL_LEGACY_GROUP_ID;
-            }
+        if (groupTracker instanceof Integer) {
+            group = (Integer) groupTracker + 1;
+            request.setAttribute(REQUEST_ATTR_PREDICATE_GROUP_TRACKER, group);
+            return true;
+        }
 
-            if (legacyGroupTracker instanceof Integer) {
-                group = (Integer) legacyGroupTracker + 1;
-                request.setAttribute(REQUEST_ATTR_LEGACY_PREDICATE_GROUP_TRACKER, group);
-            } else {
-                group = -1;
-            }
+        return false;
+    }
+
+    /**
+     * Set the legacy groupId and set the request attribute.
+     *
+     * @param request the Sling Http Request object.
+     */
+    private void generateLegacyGroupId(SlingHttpServletRequest request) {
+        Object legacyGroupTracker = request.getAttribute(REQUEST_ATTR_LEGACY_PREDICATE_GROUP_TRACKER);
+
+        if (legacyGroupTracker == null) {
+            legacyGroupTracker = INITIAL_LEGACY_GROUP_ID;
+        }
+
+        if (legacyGroupTracker instanceof Integer) {
+            group = (Integer) legacyGroupTracker + 1;
+            request.setAttribute(REQUEST_ATTR_LEGACY_PREDICATE_GROUP_TRACKER, group);
+        } else {
+            group = -1;
         }
     }
 }

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/.content.xml
@@ -22,5 +22,5 @@
     jcr:title="Date Range Filter"
     componentGroup="Asset Share Commons - Search"
     cq:icon="calendar"
-    generatePredicateId="{Boolean}true"
+    generatePredicateGroupId="{Boolean}true"
     jcr:description="Allows a user to filter search results by a date range or relative date range property."/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/.content.xml
@@ -22,4 +22,5 @@
     jcr:title="Date Range Filter"
     componentGroup="Asset Share Commons - Search"
     cq:icon="calendar"
+    generatePredicateId="{Boolean}true"
     jcr:description="Allows a user to filter search results by a date range or relative date range property."/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/_cq_editConfig/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/_cq_editConfig/.content.xml
@@ -22,5 +22,6 @@
     dialogLayout="fullscreen">
     <cq:listeners
         jcr:primaryType="cq:EditListenersConfig"
+        afterinsert="REFRESH_PAGE"
         afteredit="REFRESH_PAGE"/>
 </jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/.content.xml
@@ -22,4 +22,5 @@
     jcr:title="Property Filter"
     sling:resourceSuperType="core/wcm/components/form/options/v1/options"
     componentGroup="Asset Share Commons - Search"
+    generatePredicateId="{Boolean}true"
     jcr:description="Allows a user to filter search results by a jcr metadata property."/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/.content.xml
@@ -22,5 +22,5 @@
     jcr:title="Property Filter"
     sling:resourceSuperType="core/wcm/components/form/options/v1/options"
     componentGroup="Asset Share Commons - Search"
-    generatePredicateId="{Boolean}true"
+    generatePredicateGroupId="{Boolean}true"
     jcr:description="Allows a user to filter search results by a jcr metadata property."/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/_cq_editConfig/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/_cq_editConfig/.content.xml
@@ -22,5 +22,6 @@
     dialogLayout="fullscreen">
     <cq:listeners
         jcr:primaryType="cq:EditListenersConfig"
+        afterinsert="REFRESH_PAGE"
         afteredit="REFRESH_PAGE"/>
 </jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/.content.xml
@@ -23,5 +23,5 @@
     sling:resourceSuperType="asset-share-commons/components/search/property"
     componentGroup="Asset Share Commons - Search"
     cq:icon="tags"
-    generatePredicateId="{Boolean}true"
+    generatePredicateGroupId="{Boolean}true"
     jcr:description="Allows a user to filter search results based on cq:tags"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/.content.xml
@@ -23,4 +23,5 @@
     sling:resourceSuperType="asset-share-commons/components/search/property"
     componentGroup="Asset Share Commons - Search"
     cq:icon="tags"
+    generatePredicateId="{Boolean}true"
     jcr:description="Allows a user to filter search results based on cq:tags"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/_cq_editConfig.xml
@@ -22,5 +22,6 @@
     dialogLayout="floating">
     <cq:listeners
         jcr:primaryType="cq:EditListenersConfig"
+        afterinsert="REFRESH_PAGE"
         afteredit="REFRESH_PAGE"/>
 </jcr:root>


### PR DESCRIPTION
* Set the 3 predicate components to refresh the page after insert generating the proper predicateId.
* Sequentially count cq:Components that are marked w `[cq:Component]@generatePredicateGroupId=true` so group id's are sequential: 1,2,3,4... vs 5,6,9,13
* Fallback legacy groupId functionality that starts groups at 10000 incase someone is using components that don't have this property. they will still work, just have oddly high group ids.
  
WDYT @arpithaar @kaushalmall ?