### PR TITLE
#108 - Add option to exclude original assets from download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-## [Unrelease]
+
+## [Unreleased]
+
+### Changed
+
+- 0108: Updated Download Modal to all for the exclusion of original assets in the download zip.
 
 ## [v1.1.2]
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/_cq_dialog/.content.xml
@@ -81,7 +81,7 @@
                     </tab-1>
                     <tab-2
                         jcr:primaryType="nt:unstructured"
-                        jcr:title="File"
+                        jcr:title="Download Options"
                         sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
                         margin="{Boolean}true">
                         <items jcr:primaryType="nt:unstructured">
@@ -89,14 +89,22 @@
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/container">
                                 <items jcr:primaryType="nt:unstructured">
+                                    <exclude-original-assets
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                            fieldDescription="Check to exclude the original renditions from the download. Checking this forces Include Renditions to be checked."
+                                            text="Exclude Original Assets from ZIP File"
+                                            name="./excludeOriginalAssets"
+                                            value="{Boolean}true"
+                                            uncheckedValue="{Boolean}false"/>
                                     <zip-file-name
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                        emptyText="Assets"
-                                        fieldDescription="The name of the file that a user will download."
-                                        fieldLabel="ZIP File Name"
-                                        name="./zipFileName"
-                                        required="{Boolean}true"/>
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                            emptyText="Assets"
+                                            fieldDescription="The name of the file that a user will download."
+                                            fieldLabel="ZIP File Name"
+                                            name="./zipFileName"
+                                            required="{Boolean}true"/>
                                 </items>
                             </column>
                         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
@@ -16,7 +16,8 @@
   ~ limitations under the License.
  */-->
 
-<sly data-sly-use.download="com.adobe.aem.commons.assetshare.components.actions.download.Download"></sly>
+<sly data-sly-use.download="com.adobe.aem.commons.assetshare.components.actions.download.Download"
+     data-sly-test.downloadAssets="${properties.excludeOriginalAssets ? false : true}"></sly>
 
 <style data-sly-test="${!wccmode.disabled}">
     .cmp-modal-download .ui.modal {
@@ -33,6 +34,9 @@
 
     <input type="hidden" name="licenseCheck" value="true"/>
     <input type="hidden" name="flatStructure" value="false"/>
+
+    <input type="hidden" name="downloadAssets"
+           value="${downloadAssets ? 'true' : 'false'}"/>
 
     <i class="close icon"></i>
 
@@ -63,8 +67,11 @@
 
             <div class="field">
                 <div class="ui checkbox">
-                    <input type="checkbox" tabindex="3" class="hidden" name="downloadRenditions" value="true">
-                    <label>${"Include Renditions" @ i18n}</label>
+                    <input type="checkbox" tabindex="3" class="hidden" name="downloadRenditions" value="true"
+                           data-sly-attribute.checked="${!downloadAssets}"
+                           data-sly-attribute.required="${!downloadAssets}"
+                           data-sly-attribute.readonly="${!downloadAssets}">
+                    <label>${"Include Renditions" @ i18n} ${downloadAssets}</label>
                 </div>
             </div>
 


### PR DESCRIPTION
@harincar what do you think about this wrt to #108 

Added checkbox to exclude original from dialog, since the end-user may not realize if the original is too big or not to attempt.

![image](https://user-images.githubusercontent.com/1451868/35133303-92745e1c-fc9d-11e7-8dc6-4d3535b363bf.png)

If the original is excluded then the Include Renditions checkbox is force-selected.

![image](https://user-images.githubusercontent.com/1451868/35133323-a6c0cf7c-fc9d-11e7-98fe-6130781c5274.png)
