### PR TITLE
#128 - Path Filter search component

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,4 +1,0 @@
-updateChangelogComment: >
-  Thanks for opening this pull request! The maintainers of this repository would appreciate it if you would update the CHANGELOG.md file with this pull request.
-updateChangelogWhiteList:
-  - task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - 0128: Path Filter search component.
+- 0130: Added auto-search capabilities to search predicate components.
 
 ## [v1.2.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.3.0]
+
+### Added
+- 0128: Path Filter search component.
+
 ## [v1.2.2]
 
 ### Fixed

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,6 +132,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-email</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>RELEASE</version>
+        </dependency>
     </dependencies>
 
 	<!-- ====================================================================== -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -136,6 +136,7 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>RELEASE</version>
+			<scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/AbstractPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/AbstractPredicate.java
@@ -29,6 +29,8 @@ import org.apache.sling.models.annotations.Required;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
+import java.util.Arrays;
+
 public abstract class AbstractPredicate implements Predicate {
     private static final String REQUEST_ATTR_PREDICATE_GROUP_TRACKER = "asset-share-commons__predicate-group";
     private static final String REQUEST_ATTR_LEGACY_PREDICATE_GROUP_TRACKER = "asset-share-commons__legacy_predicate-group";
@@ -106,6 +108,13 @@ public abstract class AbstractPredicate implements Predicate {
         }
 
         return REQUEST_ATTR_FORM_ID_TRACKER + "__" + String.valueOf(request.getAttribute(REQUEST_ATTR_FORM_ID_TRACKER));
+    }
+
+    /**
+     * @return true if the request appears to be a request that has search parameters.
+     */
+    public boolean isParameterizedSearchRequest() {
+        return Arrays.stream(new String[]{"p.", "", "_group."}).anyMatch(needle -> StringUtils.contains(request.getQueryString(), needle));
     }
 
     /**

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/FulltextPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/FulltextPredicate.java
@@ -20,6 +20,8 @@
 package com.adobe.aem.commons.assetshare.components.predicates;
 
 import com.adobe.cq.wcm.core.components.models.form.Text;
+import org.osgi.annotation.versioning.ProviderType;
 
+@ProviderType
 public interface FulltextPredicate extends Text {
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/HiddenPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/HiddenPredicate.java
@@ -25,6 +25,11 @@ import java.util.Map;
 
 @ProviderType
 public interface HiddenPredicate extends Predicate {
+    /**
+     *
+     * @param groupId the groupId to namespace these QueryBuilder parameters to.
+     * @return a map of query builder parameters for this predicate, namespaced by the groupId.
+     */
     Map<String, String> getParams(int groupId);
 }
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PathPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PathPredicate.java
@@ -19,33 +19,28 @@
 
 package com.adobe.aem.commons.assetshare.components.predicates;
 
+import com.adobe.cq.wcm.core.components.models.form.OptionItem;
+import com.adobe.cq.wcm.core.components.models.form.Options;
 import org.osgi.annotation.versioning.ProviderType;
 
 import java.util.List;
-import java.util.Map;
 
 @ProviderType
-public interface PagePredicate extends Predicate {
-    enum ParamTypes {
-        NODE_TYPE,
-        PATH,
-        GUESS_TOTAL,
-        LIMIT,
-        HIDDEN_PREDICATES
-    }
+public interface PathPredicate extends Predicate {
 
-    String getOrderBy();
+    /**
+     * @return a list of the Path filtering options.
+     */
+    List<OptionItem> getItems();
 
-    String getOrderBySort();
+    /**
+     * @return the Options.Type (checkbox, drop-down, etc.)
+     */
+    Options.Type getType();
 
-    int getLimit();
-
-    String getGuessTotal();
-
-    List<String> getPaths();
-
-    Map<String, String> getParams();
-
-    Map<String, String> getParams(ParamTypes... excludeParamTypes);
-
+    /**
+     * @return the variation of the type (checkbox or radio)
+     */
+    String getSubType();
 }
+

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/Predicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/Predicate.java
@@ -22,7 +22,9 @@ package com.adobe.aem.commons.assetshare.components.predicates;
 import com.adobe.aem.commons.assetshare.components.Component;
 import com.adobe.cq.wcm.core.components.models.form.Field;
 import org.apache.sling.api.resource.ValueMap;
+import org.osgi.annotation.versioning.ConsumerType;
 
+@ConsumerType
 public interface Predicate extends Component, Field {
 
     /**

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PropertyPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PropertyPredicate.java
@@ -21,25 +21,53 @@ package com.adobe.aem.commons.assetshare.components.predicates;
 
 import com.adobe.cq.wcm.core.components.models.form.OptionItem;
 import com.adobe.cq.wcm.core.components.models.form.Options;
+import org.osgi.annotation.versioning.ProviderType;
 
 import java.util.List;
 
+@ProviderType
 public interface PropertyPredicate extends Predicate {
 
+    /**
+     * @return the querybuilder predication operation (equals, not equals, exists)
+     */
     String getOperation();
 
+    /**
+     * @return true if the predicate's "and" operation is set.
+     */
     boolean hasAnd();
 
+    /**
+     * This is typically preceded by hasAnd() since if the and operation is NOT set, then this will return false.
+     *
+     * @return the value of the and operation.
+     */
     Boolean getAnd();
 
+    /**
+     * @return the option items for this predicate.
+     */
     List<OptionItem> getItems();
 
+    /**
+     * @return the configured input type (checkbox, radio, drop-down, etc.)
+     */
     Options.Type getType();
 
+    /**
+     * @return the configured sub-type (checkbox, toggle, slider, radio buttons)
+     */
     String getSubType();
 
+    /**
+     * @return the relative property path used for this predicate.
+     */
     String getProperty();
 
+    /**
+     * @return the predicate's key that indicates the predicates values.
+     */
     String getValuesKey();
 
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/TagsPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/TagsPredicate.java
@@ -19,28 +19,11 @@
 
 package com.adobe.aem.commons.assetshare.components.predicates;
 
-import com.adobe.cq.wcm.core.components.models.form.OptionItem;
-import com.adobe.cq.wcm.core.components.models.form.Options;
+import org.osgi.annotation.versioning.ProviderType;
 
-import java.util.List;
+@ProviderType
+public interface TagsPredicate extends PropertyPredicate {
 
-public interface TagsPredicate extends Predicate {
+    // TagsPredicate is a special case (impl details) of the PropertyPredicate.
 
-    String getOperation();
-
-    boolean hasOperation();
-
-    boolean hasAnd();
-
-    Boolean getAnd();
-
-    List<OptionItem> getItems();
-
-    Options.Type getType();
-
-    String getSubType();
-
-    String getProperty();
-
-    String getValuesKey();
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/DatePredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/DatePredicateImpl.java
@@ -50,6 +50,9 @@ import java.util.List;
 public class DatePredicateImpl extends AbstractPredicate implements DatePredicate {
     protected static final String RESOURCE_TYPE = "asset-share-commons/components/search/date-range";
 
+    private static final String RELATIVE_DATE_RANGE = "relativedaterange";
+    private static final String DATE_RANGE = "daterange";
+
     @Self
     @Required
     private SlingHttpServletRequest request;
@@ -133,7 +136,7 @@ public class DatePredicateImpl extends AbstractPredicate implements DatePredicat
 
     @Override
     public boolean isReady() {
-        return ("relativedaterange".equals(dateType) && getItems().size() > 0) || "daterange".equals(dateType);
+        return (RELATIVE_DATE_RANGE.equals(dateType) && coreOptions.getItems().size() > 0) || DATE_RANGE.equals(dateType);
     }
 
     @Override

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PathPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PathPredicateImpl.java
@@ -32,6 +32,7 @@ import com.day.cq.search.eval.PathPredicateEvaluator;
 import org.apache.commons.lang.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.request.RequestParameter;
+import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
@@ -93,11 +94,14 @@ public class PathPredicateImpl extends AbstractPredicate implements PathPredicat
         final List<OptionItem> processedOptionItems = new ArrayList<>();
 
         for (final OptionItem optionItem : coreOptions.getItems()) {
-            if (PredicateUtil.isOptionInInitialValues(optionItem, initialValues)) {
-                processedOptionItems.add(new SelectedOptionItem(optionItem));
-                foundValueFromRequest = true;
-            } else {
-                processedOptionItems.add((optionItem));
+            if (request.getResourceResolver().getResource(optionItem.getValue()) != null) {
+                // Resource must be read-able by this user for them to see the option
+                if (PredicateUtil.isOptionInInitialValues(optionItem, initialValues)) {
+                    processedOptionItems.add(new SelectedOptionItem(optionItem));
+                    foundValueFromRequest = true;
+                } else {
+                    processedOptionItems.add((optionItem));
+                }
             }
         }
         return processedOptionItems;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PathPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PathPredicateImpl.java
@@ -20,6 +20,7 @@
 package com.adobe.aem.commons.assetshare.components.predicates.impl;
 
 import com.adobe.aem.commons.assetshare.components.predicates.AbstractPredicate;
+import com.adobe.aem.commons.assetshare.components.predicates.PathPredicate;
 import com.adobe.aem.commons.assetshare.components.predicates.PropertyPredicate;
 import com.adobe.aem.commons.assetshare.components.predicates.impl.options.SelectedOptionItem;
 import com.adobe.aem.commons.assetshare.search.impl.predicateevaluators.PropertyValuesPredicateEvaluator;
@@ -48,13 +49,12 @@ import java.util.Map;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {PropertyPredicate.class},
-        resourceType = {PropertyPredicateImpl.RESOURCE_TYPE},
+        adapters = {PathPredicate.class},
+        resourceType = {PathPredicateImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )
-public class PropertyPredicateImpl extends AbstractPredicate implements PropertyPredicate, Options {
-
-    protected static final String RESOURCE_TYPE = "asset-share-commons/components/search/property";
+public class PathPredicateImpl extends AbstractPredicate implements PathPredicate, Options {
+    protected static final String RESOURCE_TYPE = "asset-share-commons/components/search/path";
     protected static final String PN_TYPE = "type";
 
     protected String valueFromRequest = null;
@@ -73,21 +73,13 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
     private String label;
 
     @ValueMapValue
-    private String property;
-
-    @ValueMapValue
     private String operation;
 
     @ValueMapValue
     private Boolean expanded;
 
-    @ValueMapValue(name = PropertyPredicateImpl.PN_TYPE)
+    @ValueMapValue(name = PathPredicateImpl.PN_TYPE)
     private String typeString;
-
-    @ValueMapValue
-    @Named("and")
-    @Default(booleanValues = false)
-    private boolean and;
 
     @PostConstruct
     protected void init() {
@@ -117,39 +109,15 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
 
     /* Property Predicate Specific */
 
+    @Override
     public String getSubType() {
         //support variation of Checkboxes
         return typeString;
     }
 
-    public String getProperty() {
-        return property;
-    }
-
-    @Override
-    public String getValuesKey() {
-        return PropertyValuesPredicateEvaluator.VALUES;
-    }
-
-    public boolean hasOperation() {
-        return StringUtils.isNotBlank(getOperation());
-    }
-
-    public String getOperation() {
-        return operation;
-    }
-
-    public boolean hasAnd() {
-        return and;
-    }
-
-    public Boolean getAnd() {
-        return and;
-    }
-
     @Override
     public String getName() {
-        return PropertyValuesPredicateEvaluator.PREDICATE_NAME;
+        return PathPredicateEvaluator.PATH;
     }
 
     @Override
@@ -160,7 +128,7 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
     @Override
     public String getInitialValue() {
         if (valueFromRequest == null) {
-            valueFromRequest = PredicateUtil.getInitialValue(request, this, PropertyValuesPredicateEvaluator.VALUES);
+            valueFromRequest = PredicateUtil.getInitialValue(request, this, getName());
         }
 
         return valueFromRequest;
@@ -169,7 +137,7 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
     @Override
     public ValueMap getInitialValues() {
         if (valuesFromRequest == null) {
-            valuesFromRequest = PredicateUtil.getInitialValues(request, this, PropertyValuesPredicateEvaluator.VALUES);
+            valuesFromRequest = PredicateUtil.getInitialValues(request, this, getName());
         }
 
         return valuesFromRequest;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
@@ -101,15 +101,17 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
         final List<OptionItem> processedOptionItems = new ArrayList<>();
         final boolean useDefaultSelected = !isParameterizedSearchRequest();
 
-        for (final OptionItem optionItem : coreOptions.getItems()) {
-            if (PredicateUtil.isOptionInInitialValues(optionItem, initialValues)) {
-                processedOptionItems.add(new SelectedOptionItem(optionItem));
-            } else if (useDefaultSelected) {
-                processedOptionItems.add((optionItem));
-            } else {
-                processedOptionItems.add(new UnselectedOptionItem(optionItem));
-            }
-        }
+        coreOptions.getItems().stream()
+                .forEach(optionItem -> {
+                    if (PredicateUtil.isOptionInInitialValues(optionItem, initialValues)) {
+                        processedOptionItems.add(new SelectedOptionItem(optionItem));
+                    } else if (useDefaultSelected) {
+                        processedOptionItems.add(optionItem);
+                    } else {
+                        processedOptionItems.add(new UnselectedOptionItem(optionItem));
+                    }
+                });
+
         return processedOptionItems;
     }
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
@@ -22,6 +22,7 @@ package com.adobe.aem.commons.assetshare.components.predicates.impl;
 import com.adobe.aem.commons.assetshare.components.predicates.AbstractPredicate;
 import com.adobe.aem.commons.assetshare.components.predicates.PropertyPredicate;
 import com.adobe.aem.commons.assetshare.components.predicates.impl.options.SelectedOptionItem;
+import com.adobe.aem.commons.assetshare.components.predicates.impl.options.UnselectedOptionItem;
 import com.adobe.aem.commons.assetshare.search.impl.predicateevaluators.PropertyValuesPredicateEvaluator;
 import com.adobe.aem.commons.assetshare.util.PredicateUtil;
 import com.adobe.cq.commerce.common.ValueMapDecorator;
@@ -59,7 +60,6 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
 
     protected String valueFromRequest = null;
     protected ValueMap valuesFromRequest = null;
-    protected boolean foundValueFromRequest = false;
 
     @Self
     @Required
@@ -99,13 +99,15 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
     public List<OptionItem> getItems() {
         final ValueMap initialValues = getInitialValues();
         final List<OptionItem> processedOptionItems = new ArrayList<>();
+        final boolean useDefaultSelected = !isParameterizedSearchRequest();
 
         for (final OptionItem optionItem : coreOptions.getItems()) {
             if (PredicateUtil.isOptionInInitialValues(optionItem, initialValues)) {
                 processedOptionItems.add(new SelectedOptionItem(optionItem));
-                foundValueFromRequest = true;
-            } else {
+            } else if (useDefaultSelected) {
                 processedOptionItems.add((optionItem));
+            } else {
+                processedOptionItems.add(new UnselectedOptionItem(optionItem));
             }
         }
         return processedOptionItems;
@@ -154,7 +156,7 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
 
     @Override
     public boolean isReady() {
-        return getItems().size() > 0;
+        return coreOptions.getItems().size() > 0;
     }
 
     @Override

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/options/UnselectedOptionItem.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/options/UnselectedOptionItem.java
@@ -17,18 +17,35 @@
  *
  */
 
-package com.adobe.aem.commons.assetshare.components.predicates;
+package com.adobe.aem.commons.assetshare.components.predicates.impl.options;
 
 import com.adobe.cq.wcm.core.components.models.form.OptionItem;
-import org.osgi.annotation.versioning.ProviderType;
 
-import java.util.List;
+public class UnselectedOptionItem implements OptionItem {
 
-@ProviderType
-public interface SortPredicate extends Predicate {
-    /**
-     * @return the option items for this predicate.
-     */
-    List<OptionItem> getItems();
+    private OptionItem wrappedOptionItem = null;
+
+    public UnselectedOptionItem(OptionItem wrappedOptionItem) {
+        this.wrappedOptionItem = wrappedOptionItem;
+    }
+
+    @Override
+    public boolean isSelected() {
+        return false;
+    }
+
+    @Override
+    public boolean isDisabled() {
+        return wrappedOptionItem.isDisabled();
+    }
+
+    @Override
+    public String getValue() {
+        return wrappedOptionItem.getValue();
+    }
+
+    @Override
+    public String getText() {
+        return wrappedOptionItem.getText();
+    }
 }
-

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/providers/impl/QuerySearchProviderImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/providers/impl/QuerySearchProviderImpl.java
@@ -39,6 +39,7 @@ import com.day.cq.search.QueryBuilder;
 import com.day.cq.search.eval.PathPredicateEvaluator;
 import com.day.cq.search.result.Hit;
 import com.day.cq.search.result.SearchResult;
+import com.day.text.Text;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.vault.util.PathUtil;
@@ -187,7 +188,7 @@ public class QuerySearchProviderImpl implements SearchProvider {
 
         boolean hasAllowed = false;
         for (final String key : pathPredicates.keySet()) {
-            final String value = PathUtil.makePath("", pathPredicates.get(key, String.class));
+            final String value = Text.makeCanonicalPath(pathPredicates.get(key, String.class));
 
             if (StringUtils.startsWithAny(value, allowedPathPrefixes) || allowedPaths.contains(value)) {
                 hasAllowed = true;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/providers/impl/QuerySearchProviderImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/providers/impl/QuerySearchProviderImpl.java
@@ -30,15 +30,22 @@ import com.adobe.aem.commons.assetshare.search.results.AssetResult;
 import com.adobe.aem.commons.assetshare.search.results.Result;
 import com.adobe.aem.commons.assetshare.search.results.Results;
 import com.adobe.aem.commons.assetshare.search.results.impl.results.QueryBuilderResultsImpl;
+import com.adobe.aem.commons.assetshare.util.PredicateUtil;
+import com.adobe.cq.commerce.common.ValueMapDecorator;
 import com.day.cq.search.Predicate;
 import com.day.cq.search.PredicateGroup;
 import com.day.cq.search.Query;
 import com.day.cq.search.QueryBuilder;
+import com.day.cq.search.eval.PathPredicateEvaluator;
 import com.day.cq.search.result.Hit;
 import com.day.cq.search.result.SearchResult;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.vault.util.PathUtil;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.request.RequestParameter;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.factory.ModelFactory;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -144,7 +151,12 @@ public class QuerySearchProviderImpl implements SearchProvider {
         }
 
         final PagePredicate pagePredicate = request.adaptTo(PagePredicate.class);
-        params.putAll(pagePredicate.getParams());
+
+        if (isPathsProvidedByRequestParams(pagePredicate, params)) {
+            params.putAll(pagePredicate.getParams(PagePredicate.ParamTypes.PATH));
+        } else {
+            params.putAll(pagePredicate.getParams());
+        }
 
         // If not provided, use the defaults set on the Search Component resource
         if (params.get(Predicate.ORDER_BY) == null) {
@@ -163,9 +175,35 @@ public class QuerySearchProviderImpl implements SearchProvider {
         return params;
     }
 
+    private boolean isPathsProvidedByRequestParams(final PagePredicate pagePredicate, final Map<String, String> requestParams) {
+        final ValueMap pathPredicates = PredicateUtil.findPredicate(requestParams, PathPredicateEvaluator.PATH, PathPredicateEvaluator.PATH);
+
+        if (pathPredicates.size() == 0) {
+            return false;
+        }
+
+        final List<String> allowedPaths = pagePredicate.getPaths();
+        final String[] allowedPathPrefixes = pagePredicate.getPaths().stream().map(path ->  StringUtils.removeEnd(path, "/") + "/").toArray(String[]::new);
+
+        boolean hasAllowed = false;
+        for (final String key : pathPredicates.keySet()) {
+            final String value = PathUtil.makePath("", pathPredicates.get(key, String.class));
+
+            if (StringUtils.startsWithAny(value, allowedPathPrefixes) || allowedPaths.contains(value)) {
+                hasAllowed = true;
+            } else {
+                requestParams.remove(key);
+            }
+        }
+
+        return hasAllowed;
+    }
+
+
     private void cleanParams(Map<String, String> params) {
         params.remove("mode");
         params.remove("layout");
+        params.remove("wcmmode");
     }
 
     private void debugPreQuery(Map <String, String> params) {

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/providers/impl/QuerySearchProviderImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/providers/impl/QuerySearchProviderImpl.java
@@ -163,6 +163,7 @@ public class QuerySearchProviderImpl implements SearchProvider {
         if (params.get(Predicate.ORDER_BY) == null) {
             params.put(Predicate.ORDER_BY, pagePredicate.getOrderBy());
         }
+
         if (params.get(Predicate.ORDER_BY + "." + Predicate.PARAM_SORT) == null) {
             params.put(Predicate.ORDER_BY + "." + Predicate.PARAM_SORT, pagePredicate.getOrderBySort());
         }
@@ -188,9 +189,9 @@ public class QuerySearchProviderImpl implements SearchProvider {
 
         boolean hasAllowed = false;
         for (final String key : pathPredicates.keySet()) {
-            final String value = Text.makeCanonicalPath(pathPredicates.get(key, String.class));
+            final String path = Text.makeCanonicalPath(pathPredicates.get(key, String.class));
 
-            if (StringUtils.startsWithAny(value, allowedPathPrefixes) || allowedPaths.contains(value)) {
+            if (StringUtils.startsWithAny(path, allowedPathPrefixes) || allowedPaths.contains(path)) {
                 hasAllowed = true;
             } else {
                 requestParams.remove(key);

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/PredicateUtil.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/PredicateUtil.java
@@ -19,12 +19,22 @@
 
 package com.adobe.aem.commons.assetshare.util;
 
+import com.adobe.aem.commons.assetshare.components.predicates.Predicate;
+import com.adobe.cq.commerce.common.ValueMapDecorator;
 import com.adobe.cq.wcm.core.components.models.form.OptionItem;
+import com.day.cq.search.eval.PathPredicateEvaluator;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.request.RequestParameter;
 import org.apache.sling.api.resource.ValueMap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Utility class that helps with common patterns found in Predicate implementations.
@@ -92,5 +102,79 @@ public final class PredicateUtil {
         }
 
         return found;
+    }
+
+    /**
+     * Finds initial predicate value from the request.
+     *
+     * @param request the request.
+     * @param predicate the predicate.
+     * @param predicateValueName the predicate value name.
+     * @return a map of the initial values.
+     */
+    public static String getInitialValue(SlingHttpServletRequest request, Predicate predicate, String predicateValueName) {
+        RequestParameter requestParameter = request.getRequestParameter(predicate.getGroup() + "." + predicate.getName() + "." + predicateValueName);
+        if (requestParameter != null) {
+            return requestParameter.getString();
+        } else {
+            return "";
+        }
+    }
+
+    /**
+     * Finds initial predicate values from the request.
+     *
+     * @param request the request.
+     * @param predicate the predicate.
+     * @param predicateValueName the predicate value name.
+     * @return a map of the initial values.
+     */
+    public static ValueMap getInitialValues(SlingHttpServletRequest request, Predicate predicate, String predicateValueName) {
+        ValueMap valuesFromRequest = new ValueMapDecorator(new HashMap<>());
+
+        for (final Map.Entry<String, RequestParameter[]> entry : request.getRequestParameterMap().entrySet()) {
+            final List<String> values = new ArrayList<>();
+
+            if (entry.getKey().matches("^" + predicate.getGroup() + "." + predicate.getName() + ".\\d*_?" + predicateValueName + "$")) {
+                for (final RequestParameter tmp : entry.getValue()) {
+                    if (org.apache.commons.lang.StringUtils.isNotBlank(tmp.getString())) {
+                        values.add(tmp.getString());
+                    }
+                }
+            }
+
+            if (!values.isEmpty()) {
+                valuesFromRequest.put(entry.getKey(), values.toArray(new String[values.size()]));
+            }
+        }
+
+        return valuesFromRequest;
+    }
+
+    /**
+     * Finds the QueryBuilder map entries that pertain to the parameterized predicate.
+     *
+     * This is helpful to find out what/which parameters are already present in a parameter map.
+     *
+     * @param queryBuilderParams the params to search through.
+     * @param predicateName the predicate name to find.
+     * @param predicateValueName the predicateName's predicate value to find. If null, it is set to the predicateName.
+     * @return a map that contains the QueryBuilder params (keys and values) that match the predicateName/predicateValueName param pair.
+     */
+    public static ValueMap findPredicate(Map<String, String> queryBuilderParams, String predicateName, String predicateValueName) {
+        if (predicateValueName == null) {
+            predicateValueName = predicateName;
+        }
+
+        final ValueMap foundPredicates = new ValueMapDecorator(new HashMap<>());
+        final Pattern p = Pattern.compile("^((\\d+_)?group\\.)?(\\d+_)?" + predicateName + "(\\.((\\d+_)?" + predicateValueName + "))?$");
+        for (final String key : queryBuilderParams.keySet()) {
+            final Matcher m = p.matcher(key);
+            if (m.matches()) {
+                foundPredicates.put(key, queryBuilderParams.get(key));
+            }
+        }
+
+        return foundPredicates;
     }
 }

--- a/core/src/test/com/adobe/aem/commons/assetshare/util/PredicateUtilTest.java
+++ b/core/src/test/com/adobe/aem/commons/assetshare/util/PredicateUtilTest.java
@@ -1,0 +1,43 @@
+package com.adobe.aem.commons.assetshare.util;
+
+import org.apache.sling.api.resource.ValueMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PredicateUtilTest {
+
+    @Test
+    void findPredicate() {
+        final Map<String, String> input = new HashMap<>();
+        input.put("group.path", "/content/dam/a/b");
+        input.put("group.path.path", "/content/dam/a/b");
+        input.put("group.path.1_path", "/content/dam/a/b");
+        input.put("1_group.path", "/content/dam/a/b");
+        input.put("1_group.path.path", "/content/dam/a/b");
+        input.put("1_group.path.1_path", "/content/dam/a/b");
+        input.put("1_group.1_path", "/content/dam/a/b");
+        input.put("1_group.1_path.path", "/content/dam/a/b");
+        input.put("1_group.1_path.1_path", "/content/dam/a/b");
+
+        input.put("type", "dam:Asset");
+
+        final Map<String, String> expected = new HashMap<>();
+        expected.put("group.path", "/content/dam/a/b");
+        expected.put("group.path.path", "/content/dam/a/b");
+        expected.put("group.path.1_path", "/content/dam/a/b");
+        expected.put("1_group.path", "/content/dam/a/b");
+        expected.put("1_group.path.path", "/content/dam/a/b");
+        expected.put("1_group.path.1_path", "/content/dam/a/b");
+        expected.put("1_group.1_path", "/content/dam/a/b");
+        expected.put("1_group.1_path.path", "/content/dam/a/b");
+        expected.put("1_group.1_path.1_path", "/content/dam/a/b");
+
+        ValueMap actual = PredicateUtil.findPredicate(input, "path", "path");
+
+        assertTrue(expected.keySet().equals(actual.keySet()));
+    }
+}

--- a/core/src/test/com/adobe/aem/commons/assetshare/util/PredicateUtilTest.java
+++ b/core/src/test/com/adobe/aem/commons/assetshare/util/PredicateUtilTest.java
@@ -12,29 +12,31 @@ class PredicateUtilTest {
 
     @Test
     void findPredicate() {
+        final String PATH = "/content/dam/a";
+
         final Map<String, String> input = new HashMap<>();
-        input.put("group.path", "/content/dam/a/b");
-        input.put("group.path.path", "/content/dam/a/b");
-        input.put("group.path.1_path", "/content/dam/a/b");
-        input.put("1_group.path", "/content/dam/a/b");
-        input.put("1_group.path.path", "/content/dam/a/b");
-        input.put("1_group.path.1_path", "/content/dam/a/b");
-        input.put("1_group.1_path", "/content/dam/a/b");
-        input.put("1_group.1_path.path", "/content/dam/a/b");
-        input.put("1_group.1_path.1_path", "/content/dam/a/b");
+        input.put("group.path", PATH);
+        input.put("group.path.path", PATH);
+        input.put("group.path.1_path", PATH);
+        input.put("1_group.path", PATH);
+        input.put("1_group.path.path", PATH);
+        input.put("1_group.path.1_path", PATH);
+        input.put("1_group.1_path", PATH);
+        input.put("1_group.1_path.path", PATH);
+        input.put("1_group.1_path.1_path", PATH);
 
         input.put("type", "dam:Asset");
 
         final Map<String, String> expected = new HashMap<>();
-        expected.put("group.path", "/content/dam/a/b");
-        expected.put("group.path.path", "/content/dam/a/b");
-        expected.put("group.path.1_path", "/content/dam/a/b");
-        expected.put("1_group.path", "/content/dam/a/b");
-        expected.put("1_group.path.path", "/content/dam/a/b");
-        expected.put("1_group.path.1_path", "/content/dam/a/b");
-        expected.put("1_group.1_path", "/content/dam/a/b");
-        expected.put("1_group.1_path.path", "/content/dam/a/b");
-        expected.put("1_group.1_path.1_path", "/content/dam/a/b");
+        expected.put("group.path", PATH);
+        expected.put("group.path.path", PATH);
+        expected.put("group.path.1_path", PATH);
+        expected.put("1_group.path", PATH);
+        expected.put("1_group.path.path", PATH);
+        expected.put("1_group.path.1_path", PATH);
+        expected.put("1_group.1_path", PATH);
+        expected.put("1_group.1_path.path", PATH);
+        expected.put("1_group.1_path.1_path", PATH);
 
         ValueMap actual = PredicateUtil.findPredicate(input, "path", "path");
 

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,18 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.17</version>
+                    <version>2.20.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-junit47</artifactId>
+                            <version>2.20.1</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <parallel>methods</parallel>
+                        <threadCount>5</threadCount>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.sling</groupId>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/path/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/path/.content.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2017]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="Path Filter"
+    sling:resourceSuperType="core/wcm/components/form/options/v1/options"
+    componentGroup="Asset Share Commons - Search"
+    generatePredicateGroupId="{Boolean}true"
+    cq:icon="graphPathing"
+    jcr:description="Allows a user to filter search results by preset paths."/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/path/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/path/_cq_dialog/.content.xml
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2018]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Path Filter"
+    sling:resourceType="cq/gui/components/authoring/dialog"
+    extraClientlibs="[core.wcm.components.form.options.v1.editor]"
+    helpPath="https://www.adobe.com/go/aem_cmp_form_options_v1">
+    <content
+        granite:class="cmp-options--editor-v1"
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <options
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                margin="{Boolean}true">
+                <items jcr:primaryType="nt:unstructured">
+                    <columns
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                        <items jcr:primaryType="nt:unstructured">
+                            <MainHeading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/heading"
+                                level="{Long}3"
+                                text="Filter"/>
+                            <optionTypes
+                                granite:class="cmp-options--editor-type-v1"
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                fieldDescription="Set the type of the form field."
+                                fieldLabel="Type"
+                                name="./type">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <checkbox
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Checkboxes"
+                                        value="checkbox"/>
+                                    <radio
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Radio buttons"
+                                        value="radio"/>
+                                    <slider
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Slider"
+                                        value="slider"/>
+                                    <toggle
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Toggle"
+                                        value="toggle"/>
+                                    <dropdown
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Drop-down"
+                                        value="drop-down"/>
+                                    <multiDropDown
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:hideResource="{Boolean}true"
+                                        text="Multi-select drop-down"
+                                        value="multi-drop-down"/>
+                                </items>
+                            </optionTypes>
+                            <title
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                fieldDescription="Legend to describe the role of the field."
+                                fieldLabel="Title"
+                                name="./jcr:title"
+                                required="{Boolean}true"/>
+                            <name
+                                jcr:primaryType="nt:unstructured"
+                                sling:hideResource="{Boolean}true"/>
+                            <expanded
+                                jcr:primaryType="nt:unstructured"
+                                sling:orderBefore="name"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                fieldDescription="Select if the field set should start in an expanded state (not applicable for drop down)"
+                                name="./expanded"
+                                text="Start Expanded"
+                                value="true"/>
+                            <source
+                                granite:class="cmp-form-options-source cq-dialog-dropdown-showhide"
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                fieldDescription="Source of the options."
+                                fieldLabel="Source"
+                                name="./source">
+                                <granite:data
+                                    jcr:primaryType="nt:unstructured"
+                                    cq-dialog-dropdown-showhide-target=".list-option-listfrom-showhide-target"/>
+                                <items jcr:primaryType="nt:unstructured">
+                                    <local
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Local"
+                                        value="local"/>
+                                    <list
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:hideResource="{Boolean}true"
+                                        text="List"
+                                        value="list"/>
+                                    <datasource
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Datasource"
+                                        value="datasource"/>
+                                </items>
+                            </source>
+                            <fromList
+                                granite:class="hide list-option-listfrom-showhide-target foundation-layout-util-vmargin"
+                                jcr:primaryType="nt:unstructured"
+                                sling:hideResource="{Boolean}true"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <granite:data
+                                    jcr:primaryType="nt:unstructured"
+                                    showhidetargetvalue="list"/>
+                                <items jcr:primaryType="nt:unstructured">
+                                    <fromList
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/pathbrowser"
+                                        fieldDescription="Path of the static list."
+                                        fieldLabel="List"
+                                        name="./listPath"/>
+                                </items>
+                            </fromList>
+                            <fromDatasource
+                                granite:class="hide list-option-listfrom-showhide-target foundation-layout-util-vmargin"
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <granite:data
+                                    jcr:primaryType="nt:unstructured"
+                                    showhidetargetvalue="datasource"/>
+                                <items jcr:primaryType="nt:unstructured">
+                                    <fromDatasource
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                        fieldDescription="Resource type of the datasource."
+                                        fieldLabel="Datasource"
+                                        name="./datasourceRT"/>
+                                </items>
+                            </fromDatasource>
+                            <fromLocal
+                                granite:class="hide list-option-listfrom-showhide-target foundation-layout-util-vmargin"
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <granite:data
+                                    jcr:primaryType="nt:unstructured"
+                                    showhidetargetvalue="local"/>
+                                <items jcr:primaryType="nt:unstructured">
+                                    <options
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                        composite="{Boolean}true"
+                                        fieldDescription="Define the different options"
+                                        fieldLabel="Options"
+                                        renderReadOnly="{Boolean}true">
+                                        <field
+                                            granite:class="cmp-options--editor-item-multifield-composite-item coral-Well"
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/container"
+                                            name="./items">
+                                            <items jcr:primaryType="nt:unstructured">
+                                                <option
+                                                    granite:class="cmp-options--editor-item-multifield-composite-item-container"
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/container">
+                                                    <items jcr:primaryType="nt:unstructured">
+                                                        <checked
+                                                            granite:class="cmp-form-option-item-active"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                            name="./selected"
+                                                            text="Active"
+                                                            uncheckedValue="false"
+                                                            value="{Boolean}true"/>
+                                                        <selected
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/radiogroup"
+                                                            name="./selected">
+                                                            <items jcr:primaryType="nt:unstructured">
+                                                                <active
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    text="Active"
+                                                                    value="{Boolean}true"/>
+                                                            </items>
+                                                        </selected>
+                                                        <disabled
+                                                            granite:class="cmp-form-option-item-disabled"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                            name="./disabled"
+                                                            text="Disabled"
+                                                            value="{Boolean}true"/>
+                                                        <text
+                                                                jcr:primaryType="nt:unstructured"
+                                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                                fieldLabel="Label"
+                                                                sling:orderBefore="value"
+                                                                name="text"/>
+                                                        <value
+                                                                jcr:primaryType="nt:unstructured"
+                                                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                                jcr:description="The absolute DAM path (starting with /content/dam) to restrict this search filter to."
+                                                                required="{Boolean}true"
+                                                                fieldLabel="Path"
+                                                                name="value"/>
+                                                    </items>
+                                                </option>
+                                            </items>
+                                        </field>
+                                    </options>
+                                </items>
+                            </fromLocal>
+                            <aboutHeading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/heading"
+                                sling:hideResource="{Boolean}true"/>
+                            <description
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                sling:hideResource="{Boolean}true"/>
+                        </items>
+                    </columns>
+                </items>
+            </options>
+        </items>
+    </content>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/path/_cq_editConfig/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/path/_cq_editConfig/.content.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2017]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:EditConfig"
+    dialogLayout="fullscreen">
+    <cq:listeners
+        jcr:primaryType="cq:EditListenersConfig"
+        afterinsert="REFRESH_PAGE"
+        afteredit="REFRESH_PAGE"/>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/path/_cq_htmlTag/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/path/_cq_htmlTag/.content.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2017]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    cq:tagName="div"
+    jcr:primaryType="nt:unstructured"
+    class="cmp cmp-search-path"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/path/path.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/path/path.html
@@ -1,0 +1,45 @@
+<!--/*
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2017]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+ */-->
+
+<sly data-sly-use.predicate="com.adobe.aem.commons.assetshare.components.predicates.PathPredicate"
+     data-sly-use.placeholderTemplate="core/wcm/components/commons/v1/templates.html"
+     data-sly-use.optionsTemplate="templates/options.html"
+	 data-sly-test.ready="${predicate.ready}">
+
+	<input type="hidden"
+		   name="${predicate.group}.p.or"
+		   value="true"
+		   form="${predicate.formId}"
+		   data-asset-share-predicate-id="${predicate.id}"/>
+
+	<!--/* CHECKBOX and Variations*/-->
+	<div class="ui form">
+		<div class="ui fluid styled accordion field"
+			 data-sly-test="${predicate.type.value == 'checkbox' || predicate.type.value == 'radio'}">
+		 <sly
+			  data-sly-call="${optionsTemplate.checkbox @ predicate = predicate}"></sly>
+		</div>
+  	</div>
+
+    <!--/* DROP-DOWN */-->
+    <div class="form-group ${predicate.type.value} ui form"
+         data-sly-test="${predicate.type.value == 'drop-down' || predicate.type.value == 'multi-drop-down'}"
+         data-sly-call="${optionsTemplate.dropdown @ predicate = predicate}"></div>
+
+</sly>
+<sly data-sly-call="${placeholderTemplate.placeholder @ isEmpty=!ready}"></sly>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/path/templates/options.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/path/templates/options.html
@@ -1,0 +1,62 @@
+<!--/*
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2017]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+ */-->
+
+<!--/* Checkbox Template also renders Radio, Toggle, and Slide formats */-->
+
+<template data-sly-template.checkbox="${ @ predicate}">
+
+<div class="${predicate.isExpanded ? 'active' : ''} title right">
+	<i class="dropdown icon"></i> ${predicate.title}
+</div>
+
+<div class="${predicate.isExpanded ? 'active' : ''} content field">
+	<div class="grouped fields"
+		 data-sly-list.option="${predicate.items}">
+		<div class="field">
+			<div class="ui ${predicate.subType} checkbox">
+				<input for="${predicate.id}"
+					   form="${predicate.formId}"
+					   type="${predicate.subType == 'checkbox' ? 'checkbox' : 'radio'}"
+					   name="${predicate.group}.${predicate.subType == 'checkbox' ? optionList.index : '0'}_${predicate.name}"
+					   value="${option.value}"
+					   checked="${option.selected}"
+					   disabled="${option.disabled}" />
+				<label>${option.text}</label>
+			</div>
+		</div>
+	</div>
+</div>
+</template>
+
+<!--/* Dropdown Template - renders a dropdown */-->
+<template data-sly-template.dropdown="${ @ predicate}">
+    <select class="ui fluid dropdown"
+            name="${predicate.group}.${predicate.name}"
+			value="${predicate.intialValue}"
+			form="${predicate.formId}"
+			for="${predicate.id}">
+    	<option value="">${predicate.title}</option>
+    	<sly data-sly-list.optionItem="${predicate.items}">
+    		<option value="${optionItem.value}"
+    		        disabled="${optionItem.disabled}"
+    		        selected="${optionItem.selected ? 'selected' : ''}">
+    		        ${optionItem.text}
+    		</option>
+    	</sly>
+    </select>
+</template>


### PR DESCRIPTION
Fixes #128

This also includes a fix i discovered where the query parameters were not setting the intial search form state (for example, check some filter check-boxes, perform a the search, and refresh the page using the query params to "save" the search) .. the search will perform however the filter input fields will not be updated to match the query params.