### PR TITLE
#131 - Fixed ContextHub eventing condition that cause the user menu p…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+
+### Fixed
+- 0131: Fixed ContextHub eventing condition that cause the user menu profile to act as "anonymous" on the first page via by an auth'd user.
+
 ## [v1.2.2]
 
 ### Fixed

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/clientlibs/site/js/profile.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/clientlibs/site/js/profile.js
@@ -18,10 +18,11 @@
 
 /*global jQuery: false, AssetShare: false, ContextHub: false*/
 
-jQuery((function($, ns, cart, contextHub, profile) {
+jQuery((function($, ns, cart) {
     "use strict";
 
-    var ANONYMOUS_SECTION_ID = "cmp-user-menu__profile--anonymous",
+    var profile = ContextHub.getStore("profile"),
+        ANONYMOUS_SECTION_ID = "cmp-user-menu__profile--anonymous",
         AUTHENTICATED_SECTION_ID = "cmp-user-menu__profile--authenticated",
         AUTHENTICATED_DISPLAY_NAME_ID = "cmp-user-menu__profile-display-name",
         AUTHENTICATED_PROFILE_PIC_ID = "cmp-user-menu__profile-pic--available",
@@ -64,11 +65,15 @@ jQuery((function($, ns, cart, contextHub, profile) {
         authenticatedSection.show();
     }
 
-    function init() {
-        if (isAnonymous()) {
-            showAnonymous();
-        } else {
-            showAuthenticated();
+    function init(event, eventData) {
+        if (eventData.store === "profile") {
+            // Only perform this check when the profile store is updated
+            // For some reason the event handler below triggers for all stores and not just the profile store.
+            if (isAnonymous()) {
+                showAnonymous();
+            } else {
+                showAuthenticated();
+            }
         }
     }
 
@@ -77,10 +82,9 @@ jQuery((function($, ns, cart, contextHub, profile) {
         cart.clear();
     });
 
-    profile.eventing.on(contextHub.Constants.EVENT_STORE_READY, init);
+    profile.eventing.on(ContextHub.Constants.EVENT_STORE_UPDATED, init);
 
 }(jQuery,
     AssetShare,
-    AssetShare.Cart,
-    ContextHub,
-    ContextHub.getStore("profile"))));
+    AssetShare.Cart)));
+


### PR DESCRIPTION
…rofile to act as "anonymous" on the first page via by an auth'd user.

Fixes #131; The initial load now briefly shows the anonymous state (Log in) link and flickers to the correct auth state. Open to improvements w/ if there are ideas wrt to the timing/event issues. The flicker is caused by the intial OOTB store intialization to anonymous, and then the subsequent update after the `../currentuser.json` check that then called `profileStore.loadProfile(..)` which in turns triggers a `store-update`.

Changed the event to listen on to the store-updated (vs store-ready) as store-ready seems to only be listenable on the first instance (doesnt make sense to me, perhaps a bug? it almost seems like its working like `once(..)` rather than `on(..)`). 

I did notice the profile.eventing.on(..) does not seem to scope the events to that store (the profile store) but rather the event binding listens on that event for ALL stores, so added a check to ensure its the profile store before processing.

Also, its quite helpful to set `ContextHub.debug(true)` when debugging issues like this to see whats going on.

To verify this behavior.
1) Login to ASC on Publish 
2) Clear all localstorage
3) Refresh the ASC page
4) See the Log In -> Welcome flicker 
5) Subsequent page loads (after the ContextHub localstorage has been initiated to the current user) no flickering occurs.


