### PR TITLE
Bind highest ranked share service

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
@@ -64,7 +64,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Component
+@Component(service = ShareService.class)
 @Designate(ocd = EmailShareServiceImpl.Cfg.class)
 public class EmailShareServiceImpl implements ShareService {
     private static final Logger log = LoggerFactory.getLogger(EmailShareServiceImpl.class);

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/ShareServlet.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/ShareServlet.java
@@ -28,6 +28,7 @@ import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +48,7 @@ import java.util.HashMap;
 public class ShareServlet extends SlingAllMethodsServlet {
     private static final Logger log = LoggerFactory.getLogger(ShareServlet.class);
 
-    @Reference
+    @Reference(policyOption = ReferencePolicyOption.GREEDY)
     private ShareService shareService;
 
     @Override


### PR DESCRIPTION
@davidjgonzalez ,

Modified ShareServlet.java to set policy option to GREEDY on ShareService reference to bind to a higher ranked service if available.

Thought for a while on binding all share services and running through accepts method and realized that the order of accepts method execution of multiple implementations cannot be promised and might result in non execution of custom implementation when the ASC implementation's accepts method returns true(assuming breaking the loop when one returns true. If there is no break, would end up execution of multiple implementations and might result in multiple mails being sent).
Thoughts ?

cc : @kaushalmall 