### PR TITLE
#134 - Multiple ShareService support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- 0134: Allow multiple ShareServices to be registered and allow each to accept the request.
+
 ## [v1.2.2]
 
 ### Fixed

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/EmailShare.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/EmailShare.java
@@ -24,11 +24,32 @@ import org.osgi.annotation.versioning.ProviderType;
 
 @ProviderType
 public interface EmailShare extends Share {
+
+    String PN_SIGNATURE = "signature";
+
+    String PN_USE_SHARER_NAME_AS_SIGNATURE = "useSharerSignature";
+
+    /**
+     * For example, in the default ASC Email Share implementation, this is the valuemap for the Email Share Modal Component.
+     *
+     * @return a value map of the share component's resource.
+     */
     ValueMap getProperties();
 
+    /**
+     * This data is considered "safe" is it is configured at the Component level by the Author, and not passed in by the end-user.
+     *
+     * @return the data provided via the Share form's component configuration.
+     */
     ValueMap getConfiguredData();
 
+    /**
+     * @return the data provided by the end user via the Share submissions form.
+     */
     ValueMap getUserData();
 
+    /**
+     * @return the absolute path to the E0mail Template to use.
+     */
     String getEmailTemplatePath();
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/ShareService.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/ShareService.java
@@ -32,6 +32,13 @@ import org.osgi.annotation.versioning.ConsumerType;
 @ConsumerType
 public interface ShareService {
     /**
+     *
+     * @param request         the request that provides context of which Asset Share instance the request is coming to.
+     * @return true if the share service should process the request.
+     */
+    boolean accepts(SlingHttpServletRequest request);
+
+    /**
      * Share method to use in the context of a request; Typically a Servlet will call this method on the appropriate ShareService implementation.
      *
      * @param request         the request that provides context of which Asset Share instance the request is coming to.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareImpl.java
@@ -49,9 +49,6 @@ import java.util.Map;
 public class EmailShareImpl extends ShareImpl implements EmailShare {
     protected static final String RESOURCE_TYPE = "asset-share-commons/components/modals/share";
 
-    public static final String PN_SIGNATURE = "signature";
-    public static final String PN_USE_SHARER_NAME_AS_SIGNATURE = "useSharerSignature";
-
     @Self
     @Required
     private SlingHttpServletRequest request;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
@@ -52,7 +52,6 @@ import org.apache.sling.xss.XSSAPI;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
@@ -64,10 +63,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Component
+@Component(service = ShareService.class)
 @Designate(ocd = EmailShareServiceImpl.Cfg.class)
 public class EmailShareServiceImpl implements ShareService {
     private static final Logger log = LoggerFactory.getLogger(EmailShareServiceImpl.class);
+
+    public static final String SHARE_SERVICE_ACCEPTANCE_KEY = "asset-share-commons__share--email";
 
     /**
      * Share Parameters
@@ -96,6 +97,11 @@ public class EmailShareServiceImpl implements ShareService {
 
     @Reference
     private XSSAPI xssAPi;
+
+    @Override
+    public boolean accepts(final SlingHttpServletRequest request) {
+        return "true".equals(request.getParameter(SHARE_SERVICE_ACCEPTANCE_KEY));
+    }
 
     @Override
     public final void share(final SlingHttpServletRequest request, final SlingHttpServletResponse response, final ValueMap shareParameters) throws ShareException {

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/ShareServlet.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/ShareServlet.java
@@ -19,6 +19,7 @@
 
 package com.adobe.aem.commons.assetshare.components.actions.share.impl;
 
+import com.adobe.aem.commons.assetshare.components.actions.share.Share;
 import com.adobe.aem.commons.assetshare.components.actions.share.ShareException;
 import com.adobe.aem.commons.assetshare.components.actions.share.ShareService;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -28,6 +29,7 @@ import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,20 +37,26 @@ import javax.jcr.RepositoryException;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
 
-@Component(service = Servlet.class, property = {
-        "sling.servlet.methods=POST",
-        "sling.servlet.resourceTypes=asset-share-commons/actions/share",
-        "sling.servlet.selectors=share",
-        "sling.servlet.extensions=html",
-        "sling.servlet.extensions=json"
-})
+@Component(service = Servlet.class,
+           property = {
+            "sling.servlet.methods=POST",
+            "sling.servlet.resourceTypes=asset-share-commons/actions/share",
+            "sling.servlet.selectors=share",
+            "sling.servlet.extensions=html",
+            "sling.servlet.extensions=json"
+            }
+)
 public class ShareServlet extends SlingAllMethodsServlet {
     private static final Logger log = LoggerFactory.getLogger(ShareServlet.class);
 
-    @Reference
-    private ShareService shareService;
+    @Reference(target = "(component.name=com.adobe.aem.commons.assetshare.components.actions.share.impl.EmailShareServiceImpl)")
+    private ShareService defaultShareService;
+
+    @Reference(policyOption = ReferencePolicyOption.GREEDY)
+    private transient Collection<ShareService> shareServices;
 
     @Override
     protected final void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
@@ -62,13 +70,20 @@ public class ShareServlet extends SlingAllMethodsServlet {
 
     private final void share(SlingHttpServletRequest request, SlingHttpServletResponse response) throws RepositoryException {
         try {
-            if (shareService != null) {
-                // Make this map write-able by copying the Request parameters into a new hash map
-                final ValueMap shareParameters = new ValueMapDecorator(new HashMap<String, Object>(request.getParameterMap()));
-                // Call the best ranking Share Service
-                shareService.share(request, response, shareParameters);
-            } else {
-                throw new ShareException("No ShareService is active, so sharing is disabled");
+            // Make this map write-able by copying the Request parameters into a new hash map
+            final ValueMap shareParameters = new ValueMapDecorator(new HashMap<String, Object>(request.getParameterMap()));
+
+            int shareCount = 0;
+            // Call the best ranking Share Service
+            for(final ShareService shareService : shareServices) {
+                if (shareService.accepts(request)) {
+                    shareService.share(request, response, shareParameters);
+                    shareCount++;
+                }
+            }
+
+            if (shareCount == 0) {
+                defaultShareService.share(request, response, shareParameters);
             }
         } catch (ShareException ex) {
             log.error("Unable to share assets from Asset Share Commons", ex);

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("1.0.1")
+@Version("2.0.0")
 package com.adobe.aem.commons.assetshare.components.actions.share;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/datasources/ComputedPropertiesDataSource.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/datasources/ComputedPropertiesDataSource.java
@@ -27,7 +27,9 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
-import org.osgi.service.component.annotations.*;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,10 +37,8 @@ import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Component(
         service = Servlet.class,

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,15 @@
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>3.3.0</version>
+                    <extensions>true</extensions>
+                    <executions>
+                        <execution>
+                            <id>baseline</id>
+                            <goals>
+                                <goal>baseline</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Supports multiple ShareService implementations. If none accept, then the default ASC email based ShareService is used.

Note that MULTIPLE share services can be invoked via a single share operation.