### PR TITLE
#130 - Added support for auto-searching on predicate search components

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/AbstractPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/AbstractPredicate.java
@@ -47,6 +47,10 @@ public abstract class AbstractPredicate implements Predicate {
     @Default(booleanValues = false)
     private boolean expanded;
 
+    @ValueMapValue
+    @Default(booleanValues = false)
+    private boolean autoSearch;
+
     private int group = 1;
 
     private Field coreField;
@@ -62,6 +66,10 @@ public abstract class AbstractPredicate implements Predicate {
         }
 
         return expanded;
+    }
+
+    public boolean isAutoSearch() {
+        return autoSearch;
     }
 
     public String getGroup() {

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/Predicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/Predicate.java
@@ -29,7 +29,6 @@ public interface Predicate extends Component, Field {
      * In version 1.x.x of this project, this will always be "asset-share-commons__form-id__1".
      *
      * @return the Form id, use to bind inputs to a form via &lt;input form="${predicate.formId}"... &gt;.
-     *
      */
     String getFormId();
 
@@ -44,6 +43,15 @@ public interface Predicate extends Component, Field {
      * @return true is the predicate view should be expanded.
      */
     boolean isExpanded();
+
+    /**
+     * The support and implementation of autoSearch is component-implementation dependent.
+     *
+     * @return true if auto searching should be enabled for this predicate.
+     */
+    default boolean isAutoSearch() {
+        return false;
+    }
 
     /**
      * GUIDANCE NOTICE

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/search/search.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/search/search.js
@@ -124,6 +124,9 @@ AssetShare.Search = (function (window, $, ns, ajax) {
         $("body").on("change", ns.Elements.selector("sort"), sortResults);
         $("body").on("click", ns.Elements.selector("switch-layout"), switchLayout);
 
+        $("body").on("change", "[data-asset-share-search-on='change']", search);
+        $("body").on("click", "[data-asset-share-search-on='click']", search);
+
         /* Required for IE */
         $("button[form='" + formId + "']").on("click", search);
         $("input[form='" + formId + "']").keypress(function(e) {

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/plug-ins.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/plug-ins.js
@@ -26,34 +26,34 @@ $(function () {
     $(".ui.accordion").accordion();
     $(".ui.dropdown").dropdown();
 
-});
+    /** Semantic UI Calendar Plugins - Initialize Date Range Predicates **/
+    function dateFormatter(date, settings) {
+        var day, month, year;
 
-/** Semantic UI Calendar Plugins - Initialize Date Range Predicates **/
-$(function () {
-    "use strict";
+        if (!date) {
+            return '';
+        }
 
-    var rangeStart = $('.ui.calendar.rangestart');
+        day = date.getDate();
+        month = date.getMonth() + 1;
+        year = date.getFullYear();
 
-    $(rangeStart).each(function (index) {
+        return year + '-' + month + '-' + day;
+    }
+
+    $('.ui.calendar.rangestart').each(function (index) {
         var predicateId = $(this).attr('data-asset-share-calendar-start-id'),
+            rangeStart = $(this),
             rangeEnd = $('[data-asset-share-calendar-end-id="' + predicateId + '"]');
 
-        $(this).calendar({
+        $(rangeStart).calendar({
             type: 'date',
             endCalendar: $(rangeEnd),
             formatter: {
-                date: function (date, settings) {
-                    var day, month, year;
-
-                    if (!date) {
-                        return '';
-                    }
-                    day = date.getDate();
-                    month = date.getMonth() + 1;
-                    year = date.getFullYear();
-
-                    return year + '-' + month + '-' + day;
-                }
+                date: dateFormatter
+            },
+            onChange: function (date, text, mode) {
+                $(rangeStart).find('input[type="text"]').trigger("change");
             }
         });
 
@@ -61,18 +61,10 @@ $(function () {
             type: 'date',
             startCalendar: $(this),
             formatter: {
-                date: function (date, settings) {
-                    var day, month, year;
-
-                    if (!date) {
-                        return '';
-                    }
-                    day = date.getDate();
-                    month = date.getMonth() + 1;
-                    year = date.getFullYear();
-
-                    return year + '-' + month + '-' + day;
-                }
+                date: dateFormatter
+            },
+            onChange: function (date, text, mode) {
+                $(rangeEnd).find('input[type="text"]').trigger("change");
             }
         });
     });

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/_cq_dialog/.content.xml
@@ -69,6 +69,14 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="asset-share-commons/data-sources/filterable-properties"/>
                             </property>
+                            <auto-search
+                                jcr:primaryType="nt:unstructured"
+                                sling:orderBefore="name"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                fieldDescription="Check this field to automatically apply this filter via a new search when this value is changed."
+                                name="./autoSearch"
+                                text="Auto-Search on Change"
+                                value="true"/>
                             <expanded
                                 jcr:primaryType="nt:unstructured"
                                 sling:orderBefore="name"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/_cq_template/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/_cq_template/.content.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2018]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    autoSearch="{Boolean}true"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/templates/options.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/templates/options.html
@@ -28,7 +28,8 @@
                        name="${predicate.group}.${predicate.lowerBoundName}"
                        value="${predicate.initialLowerBound}"
                        form="${predicate.formId}"
-                       for="${predicate.id}"/>
+                       for="${predicate.id}"
+                       data-asset-share-search-on="${predicate.autoSearch ? 'change' : ''}"/>
             </div>
         </div>
     </div>
@@ -41,13 +42,14 @@
                        name="${predicate.group}.${predicate.upperBoundName}"
                        value="${predicate.initialUpperBound}"
                        form="${predicate.formId}"
-                       for="${predicate.id}"/>
+                       for="${predicate.id}"
+                       data-asset-share-search-on="${predicate.autoSearch ? 'change' : ''}"/>
             </div>
         </div>
     </div>
 </template>
 
-<!--/* Relative Date Rang  */-->
+<!--/* Relative Date Range  */-->
 <template data-sly-template.relativeDateRange="${ @ predicate}">
     <div class="grouped fields"
          data-sly-list.option="${predicate.items}">
@@ -59,7 +61,8 @@
                        name="${predicate.group}.${predicate.name}.lowerBound"
                        value="${option.value}"
                        checked="${option.selected}"
-                       disabled="${option.disabled}"/>
+                       disabled="${option.disabled}"
+                       data-asset-share-search-on="${predicate.autoSearch ? 'change' : ''}"/>
                 <label>${option.text}</label>
             </div>
         </div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/_cq_dialog/.content.xml
@@ -132,6 +132,14 @@
                                     -->
                                 </items>
                             </operation>
+                            <auto-search
+                                jcr:primaryType="nt:unstructured"
+                                sling:orderBefore="name"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                fieldDescription="Check this field to automatically apply this filter via a new search when this value is changed."
+                                name="./autoSearch"
+                                text="Auto-Search on Change"
+                                value="true"/>
                             <expanded
                                 jcr:primaryType="nt:unstructured"
                                 sling:orderBefore="name"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/_cq_template/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/_cq_template/.content.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2018]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    autoSearch="{Boolean}true"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/templates/options.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/templates/options.html
@@ -35,7 +35,8 @@
 					   name="${predicate.group}.${predicate.name}.${predicate.subType == 'checkbox' ? optionList.index : '0'}_${predicate.valuesKey}"
 					   value="${option.value}"
 					   checked="${option.selected}"
-					   disabled="${option.disabled}" />
+					   disabled="${option.disabled}"
+					   data-asset-share-search-on="${predicate.autoSearch ? 'change' : ''}"/>
 				<label>${option.text}</label>
 			</div>
 		</div>
@@ -50,8 +51,9 @@
             name="${predicate.group}.${predicate.name}.${predicate.valuesKey}"
 			value="${predicate.intialValue}"
 			form="${predicate.formId}"
-			for="${predicate.id}">
-    	<option value="">${predicate.title}</option>
+			for="${predicate.id}"
+			data-asset-share-search-on="${predicate.autoSearch ? 'change' : ''}">
+	<option value="">${predicate.title}</option>
     	<sly data-sly-list.optionItem="${predicate.items}">
     		<option value="${optionItem.value}"
     		        disabled="${optionItem.disabled}"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/sort/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/sort/_cq_dialog/.content.xml
@@ -17,80 +17,103 @@
   ~ limitations under the License.
   -->
 
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    jcr:title="Sort"
-    sling:resourceType="cq/gui/components/authoring/dialog"
-    extraClientlibs="[core.wcm.components.form.options.v1.editor]">
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:primaryType="nt:unstructured"
+          jcr:title="Sort"
+          sling:resourceType="cq/gui/components/authoring/dialog"
+          extraClientlibs="[core.wcm.components.form.options.v1.editor]">
     <content
-        granite:class="cmp-options--editor-v1"
-        jcr:primaryType="nt:unstructured"
-        sling:resourceType="granite/ui/components/coral/foundation/container">
+            granite:class="cmp-options--editor-v1"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/container">
         <items jcr:primaryType="nt:unstructured">
             <options
-                jcr:primaryType="nt:unstructured"
-                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
-                margin="{Boolean}true">
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                    margin="{Boolean}true">
                 <items jcr:primaryType="nt:unstructured">
                     <columns
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="granite/ui/components/coral/foundation/container">
                         <items jcr:primaryType="nt:unstructured">
                             <sort
-                                granite:class="foundation-layout-util-vmargin"
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                    granite:class="foundation-layout-util-vmargin"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/container">
                                 <items jcr:primaryType="nt:unstructured">
                                     <tabs
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/coral/foundation/tabs"
-                                        maxmized="{Boolean}true">
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/tabs"
+                                            maxmized="{Boolean}true">
                                         <items jcr:primaryType="nt:unstructured">
                                             <tab1
-                                                jcr:primaryType="nt:unstructured"
-                                                jcr:title="Sort By"
-                                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
-                                                margin="{Boolean}true">
+                                                    jcr:primaryType="nt:unstructured"
+                                                    jcr:title="Sort"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                                    margin="{Boolean}true">
                                                 <items jcr:primaryType="nt:unstructured">
                                                     <column
-                                                        jcr:primaryType="nt:unstructured"
-                                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/container">
+                                                        <items jcr:primaryType="nt:unstructured">
+                                                            <auto-search
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:orderBefore="name"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                                    fieldDescription="Check this field to automatically re-sort via a new search when this value is changed."
+                                                                    name="./autoSearch"
+                                                                    text="Auto-Search on Change"
+                                                                    value="true"/>
+                                                        </items>
+                                                    </column>
+                                                </items>
+                                            </tab1>
+                                            <tab2
+                                                    jcr:primaryType="nt:unstructured"
+                                                    jcr:title="Sort By"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                                    margin="{Boolean}true">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <column
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/container">
                                                         <items jcr:primaryType="nt:unstructured">
                                                             <order-by-sort-label
-                                                                jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                                fieldDescription="The label for the Sort By control."
-                                                                fieldLabel="Sort By Label"
-                                                                name="./orderByLabel"/>
-                                                            <properties
-                                                                jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
-                                                                composite="{Boolean}true"
-                                                                fieldLabel="Sort By Options"
-                                                                renderReadOnly="{Boolean}true">
-                                                                <field
-                                                                    granite:class="cmp-options--editor-item-multifield-composite-item coral-Well"
                                                                     jcr:primaryType="nt:unstructured"
-                                                                    sling:resourceType="granite/ui/components/coral/foundation/container"
-                                                                    name="./items">
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                                    fieldDescription="The label for the Sort By control."
+                                                                    fieldLabel="Sort By Label"
+                                                                    name="./orderByLabel"/>
+                                                            <properties
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                                                    composite="{Boolean}true"
+                                                                    fieldLabel="Sort By Options"
+                                                                    renderReadOnly="{Boolean}true">
+                                                                <field
+                                                                        granite:class="cmp-options--editor-item-multifield-composite-item coral-Well"
+                                                                        jcr:primaryType="nt:unstructured"
+                                                                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                                                                        name="./items">
                                                                     <items jcr:primaryType="nt:unstructured">
                                                                         <option
-                                                                            granite:class="cmp-options--editor-item-multifield-composite-item-container"
-                                                                            jcr:primaryType="nt:unstructured"
-                                                                            sling:resourceType="granite/ui/components/coral/foundation/container">
+                                                                                granite:class="cmp-options--editor-item-multifield-composite-item-container"
+                                                                                jcr:primaryType="nt:unstructured"
+                                                                                sling:resourceType="granite/ui/components/coral/foundation/container">
                                                                             <items jcr:primaryType="nt:unstructured">
                                                                                 <text
-                                                                                    jcr:primaryType="nt:unstructured"
-                                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                                                    fieldLabel="Property"
-                                                                                    name="./text"/>
-                                                                                <property
-                                                                                    jcr:primaryType="nt:unstructured"
-                                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/select"
-                                                                                    name="./value">
-                                                                                    <datasource
                                                                                         jcr:primaryType="nt:unstructured"
-                                                                                        sling:resourceType="asset-share-commons/data-sources/orderable-properties"/>
+                                                                                        sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                                                        fieldLabel="Property"
+                                                                                        name="./text"/>
+                                                                                <property
+                                                                                        jcr:primaryType="nt:unstructured"
+                                                                                        sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                                                        name="./value">
+                                                                                    <datasource
+                                                                                            jcr:primaryType="nt:unstructured"
+                                                                                            sling:resourceType="asset-share-commons/data-sources/orderable-properties"/>
                                                                                 </property>
                                                                             </items>
                                                                         </option>
@@ -100,39 +123,39 @@
                                                         </items>
                                                     </column>
                                                 </items>
-                                            </tab1>
-                                            <tab2
-                                                jcr:primaryType="nt:unstructured"
-                                                jcr:title="Sort Directions"
-                                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
-                                                margin="{Boolean}true">
+                                            </tab2>
+                                            <tab3
+                                                    jcr:primaryType="nt:unstructured"
+                                                    jcr:title="Sort Directions"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                                    margin="{Boolean}true">
                                                 <items jcr:primaryType="nt:unstructured">
                                                     <column
-                                                        jcr:primaryType="nt:unstructured"
-                                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/container">
                                                         <items jcr:primaryType="nt:unstructured">
                                                             <order-by-sort-label
-                                                                jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                                fieldDescription="The label for the Sort Direction control."
-                                                                fieldLabel="Sort Direction Label"
-                                                                name="./orderBySortLabel"/>
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                                    fieldDescription="The label for the Sort Direction control."
+                                                                    fieldLabel="Sort Direction Label"
+                                                                    name="./orderBySortLabel"/>
                                                             <ascending-label
-                                                                jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                                emptyText="Ascending"
-                                                                fieldLabel="Ascending Label"
-                                                                name="./ascendingLabel"/>
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                                    emptyText="Ascending"
+                                                                    fieldLabel="Ascending Label"
+                                                                    name="./ascendingLabel"/>
                                                             <descending-label
-                                                                jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                                emptyText="Descending"
-                                                                fieldLabel="Descending Label"
-                                                                name="./descendingLabel"/>
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                                    emptyText="Descending"
+                                                                    fieldLabel="Descending Label"
+                                                                    name="./descendingLabel"/>
                                                         </items>
                                                     </column>
                                                 </items>
-                                            </tab2>
+                                            </tab3>
                                         </items>
                                     </tabs>
                                 </items>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/sort/_cq_template/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/sort/_cq_template/.content.xml
@@ -19,6 +19,7 @@
 
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="nt:unstructured"
+    autoSearch="{Boolean}true"
     ascendingLabel="Ascending"
     descendingLabel="Descending"
     orderByLabel="Sort By"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/sort/sort.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/sort/sort.html
@@ -27,6 +27,7 @@
 				form="${predicate.formId}"
 				data-asset-share-id="sort"
 				data-asset-share-search-actions="all"
+				data-asset-share-search-on="${predicate.autoSearch ? 'change' : ''}"
 				data-sly-list.item="${predicate.items}"/>
 		<i class="dropdown icon"></i>
 		<div class="text">${properties['orderByLabel']}</div>
@@ -43,6 +44,7 @@
 				form="${predicate.formId}"
 				data-asset-share-id="sort"
 				data-asset-share-search-actions="all"
+				data-asset-share-search-on="${predicate.autoSearch ? 'change' : ''}"
 				data-sly-list.item="${predicate.items}"/>
 		<i class="dropdown icon"></i>
 		<div class="text">${properties['orderBySortLabel']}</div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/_cq_dialog/.content.xml
@@ -111,6 +111,14 @@
                                         value="unequals"/>
                                 </items>
                             </operation>
+                            <auto-search
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:orderBefore="name"
+                                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                    fieldDescription="Check this field to automatically apply this filter via a new search when this value is changed."
+                                    name="./autoSearch"
+                                    text="Auto-Search on Change"
+                                    value="true"/>
                             <expanded
                                     jcr:primaryType="nt:unstructured"
                                     sling:orderBefore="name"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/_cq_template/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/tags/_cq_template/.content.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2018]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    autoSearch="{Boolean}true"/>


### PR DESCRIPTION
Effects predicate components:
* Property
* Tags
* Sort
* PathFilter will need to be updated after merge (#128)

This feature adds a checkbox the the above components, so whenever an end user changes the component value (ie. clicks a checkbox, etc.) then a search is immediately preformed and they do not have to click "apply".