### PR TITLE
Feature/149

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/MetadataProperties.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/MetadataProperties.java
@@ -41,9 +41,9 @@ public interface MetadataProperties {
 
     /**
      * Collect the Metadata fields across Assets Metadata Schemas. To be collected the following must be true:
-     * > The metadata field must be of resource type: GraniteUI Field resource type.
-     * > Only the top-most matching field is collected (ie. in multi-value fields, the top level field is used).
-     * > The field bust have a non-blank Label AND PropertyName defined.
+     * - The metadata field must be of resource type: GraniteUI Field resource type.
+     * - Only the top-most matching field is collected (ie. in multi-value fields, the top level field is used).
+     * - The field bust have a non-blank Label AND PropertyName defined.
      *
      * @param request the request object.
      * @return a map, indexed by propertyName of propertyName -> labels[] defined in all metadata schemas that meet the metadataFieldResourceTypes acceptance check.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/MetadataProperties.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/MetadataProperties.java
@@ -27,7 +27,26 @@ import java.util.Map;
 
 @ProviderType
 public interface MetadataProperties {
-    Map<String, List<String>> getMetadataProperties(SlingHttpServletRequest request, List<String> metadataFieldTypes);
+    /**
+     * Collect the Metadata fields across Assets Metadata Schemas. To be collected the following must be true:
+     * > The metadata field must be of resource type: metadataFieldResourceTypes
+     * > Only the top-most matching field is collected (ie. in multi-value fields, the top level field is used).
+     * > The field bust have a non-blank Label AND PropertyName defined.
+     *
+     * @param request the request object.
+     * @param metadataFieldResourceTypes the sling:resourceTypes that identify candidate metadata schema widget resources.
+     * @return a map, indexed by propertyName of propertyName -> labels[] defined in all metadata schemas that meet the metadataFieldResourceTypes acceptance check.
+     */
+    Map<String, List<String>> getMetadataProperties(SlingHttpServletRequest request, List<String> metadataFieldResourceTypes);
 
+    /**
+     * Collect the Metadata fields across Assets Metadata Schemas. To be collected the following must be true:
+     * > The metadata field must be of resource type: GraniteUI Field resource type.
+     * > Only the top-most matching field is collected (ie. in multi-value fields, the top level field is used).
+     * > The field bust have a non-blank Label AND PropertyName defined.
+     *
+     * @param request the request object.
+     * @return a map, indexed by propertyName of propertyName -> labels[] defined in all metadata schemas that meet the metadataFieldResourceTypes acceptance check.
+     */
     Map<String, List<String>> getMetadataProperties(SlingHttpServletRequest request);
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/MetadataProperties.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/MetadataProperties.java
@@ -46,7 +46,7 @@ public interface MetadataProperties {
      * - The field bust have a non-blank Label AND PropertyName defined.
      *
      * @param request the request object.
-     * @return a map, indexed by propertyName of propertyName -> labels[] defined in all metadata schemas that meet the metadataFieldResourceTypes acceptance check.
+     * @return a map, indexed by propertyName of propertyName: labels[] defined in all metadata schemas that meet the metadataFieldResourceTypes acceptance check.
      */
     Map<String, List<String>> getMetadataProperties(SlingHttpServletRequest request);
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/MetadataProperties.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/MetadataProperties.java
@@ -35,7 +35,7 @@ public interface MetadataProperties {
      *
      * @param request the request object.
      * @param metadataFieldResourceTypes the sling:resourceTypes that identify candidate metadata schema widget resources.
-     * @return a map, indexed by propertyName of propertyName -> labels[] defined in all metadata schemas that meet the metadataFieldResourceTypes acceptance check.
+     * @return a map, indexed by propertyName of propertyName: labels[] defined in all metadata schemas that meet the metadataFieldResourceTypes acceptance check.
      */
     Map<String, List<String>> getMetadataProperties(SlingHttpServletRequest request, List<String> metadataFieldResourceTypes);
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/MetadataProperties.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/MetadataProperties.java
@@ -29,9 +29,9 @@ import java.util.Map;
 public interface MetadataProperties {
     /**
      * Collect the Metadata fields across Assets Metadata Schemas. To be collected the following must be true:
-     * > The metadata field must be of resource type: metadataFieldResourceTypes
-     * > Only the top-most matching field is collected (ie. in multi-value fields, the top level field is used).
-     * > The field bust have a non-blank Label AND PropertyName defined.
+     * - The metadata field must be of resource type: metadataFieldResourceTypes
+     * - Only the top-most matching field is collected (ie. in multi-value fields, the top level field is used).
+     * - The field bust have a non-blank Label AND PropertyName defined.
      *
      * @param request the request object.
      * @param metadataFieldResourceTypes the sling:resourceTypes that identify candidate metadata schema widget resources.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/datasources/MetadataSchemaPropertiesDataSource.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/datasources/MetadataSchemaPropertiesDataSource.java
@@ -29,12 +29,8 @@ import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +45,7 @@ import java.util.TreeMap;
         configurationPolicy = ConfigurationPolicy.REQUIRE
 )
 public class MetadataSchemaPropertiesDataSource extends SlingSafeMethodsServlet {
-    private static final String PN_METADATA_FIELD_TYPES = "metadataFieldTypes";
+    private static final String PN_METADATA_FIELD_RESOURCE_TYPES = "metadataFieldResourceTypes";
 
     @Reference
     private DataSourceBuilder dataSourceBuilder;
@@ -58,13 +54,12 @@ public class MetadataSchemaPropertiesDataSource extends SlingSafeMethodsServlet 
     private MetadataProperties metadataProperties;
 
     @Override
-    protected final void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws
-            ServletException, IOException {
+    protected final void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) {
         final ValueMap properties = request.getResource().getValueMap();
-        final List<String> metadataFieldTypes = Arrays.asList(properties.get(PN_METADATA_FIELD_TYPES, new String[]{}));
+        final List<String> metadataFieldResourceTypes = Arrays.asList(properties.get(PN_METADATA_FIELD_RESOURCE_TYPES, new String[]{}));
 
         final Map<String, Object> data = new TreeMap<>();
-        final Map<String, List<String>> collectedMetadata = metadataProperties.getMetadataProperties(request, metadataFieldTypes);
+        final Map<String, List<String>> collectedMetadata = metadataProperties.getMetadataProperties(request, metadataFieldResourceTypes);
 
         for (final Map.Entry<String, List<String>> entry : collectedMetadata.entrySet()) {
             final String label = StringUtils.join(entry.getValue(), " / ")


### PR DESCRIPTION
Updated the MetadataSchema Field Discovery to look at the sling:resourceTypes: must be of sling:resourceType GraniteUI (Fdn/Coral) Field to be collected as an entry in the MetadataPropertiesDataSource.

Previously the check looked at a variety of properties / combinations in an attempt to determine what a metadata field is, however this was brittle as different field sub-types put this data in different places.

/cc @artdirk