### PR TITLE
Feature/162

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
@@ -112,6 +112,7 @@ public class EmailShareServiceImpl implements ShareService {
     	
     		/** Work around for regression issue introduced in AEM 6.4 **/
         SlingBindings bindings = new SlingBindings();
+        //intentionally setting the second argument to 'null' since there is no SlingScript to pass in
         bindings.setSling( new ScriptHelper(bundleContext, null, request, response));
         request.setAttribute(SlingBindings.class.getName(), bindings);
         

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
@@ -60,8 +60,8 @@ import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import javax.jcr.RepositoryException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -230,14 +230,24 @@ public class EmailShareServiceImpl implements ShareService {
      * @param userData the Map of data provided by the end-user (usually derived from the Request) to use in the email.
      * @return the protected Map; all String's are xss protected for HTML.
      */
-    private Map<String, Object> xssProtectUserData(Map<String, Object> userData) {
-        for(final Map.Entry<String, Object> entry : userData.entrySet()) {
-            if (entry.getValue() instanceof String) {
-                userData.put(entry.getKey(), xssAPi.encodeForHTML((String)entry.getValue()));
+    private Map<String, Object> xssProtectUserData(Map<String, Object> dirtyUserData) {
+    	    
+    	    Map<String, Object> cleanUserData = new HashMap<String, Object>();
+        for(final Map.Entry<String, Object> entry : dirtyUserData.entrySet()) {
+        		
+            if (entry.getValue() instanceof String[]) {
+            		List<String> cleanValues = new ArrayList<String>();
+            		for(String val : (String[])entry.getValue()) {
+            			cleanValues.add(xssAPi.encodeForHTML(xssAPi.filterHTML(val)));
+            		}
+            		cleanUserData.put(entry.getKey(), cleanValues.toArray());
+            }
+            else if (entry.getValue() instanceof String) {
+            	    cleanUserData.put(entry.getKey(), xssAPi.encodeForHTML(xssAPi.filterHTML((String)entry.getValue())));
             }
         }
 
-        return userData;
+        return cleanUserData;
     }
 
 


### PR DESCRIPTION
HTML added in the Message body of share modal was coming through in the email and never encoded or filtered since original code was only filtering against String parameters. All of the parameters are actually String[]s.

-Explicitly creating a "clean" parameter map in case some of the parameters are not Strings or String[] and only returning the clean parameter map after it has been passed through the XSSApi.
-filtering the parameter first and then encoding the value for HTML