### PR TITLE
remoived jcr:uuid as referncable mixin has already been removed

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/resources/placeholder.jpeg/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/resources/placeholder.jpeg/.content.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:Iptc4xmpCore="http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/" xmlns:Iptc4xmpExt="http://iptc.org/std/Iptc4xmpExt/2008-02-29/" xmlns:exif="http://ns.adobe.com/exif/1.0/" xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/" xmlns:tiff="http://ns.adobe.com/tiff/1.0/" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/" xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#" xmlns:plus="http://ns.useplus.org/ldf/xmp/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dam="http://www.day.com/dam/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:mix="http://www.jcp.org/jcr/mix/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:isCheckedOut="{Boolean}true"
-    jcr:primaryType="dam:Asset"
-    jcr:uuid="404b9ba0-740f-46f2-aa03-f39c8c5015ae">
+    jcr:primaryType="dam:Asset">
     <jcr:content
         cq:name="placeholder.jpeg"
         cq:parentPath="/content/dam"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/resources/placeholder.pdf/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/resources/placeholder.pdf/.content.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:Iptc4xmpCore="http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/" xmlns:Iptc4xmpExt="http://iptc.org/std/Iptc4xmpExt/2008-02-29/" xmlns:pdf="http://ns.adobe.com/pdf/1.3/" xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:xmpGImg="http://ns.adobe.com/xap/1.0/g/img/" xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/" xmlns:xmpRights="http://ns.adobe.com/xap/1.0/rights/" xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#" xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#" xmlns:plus="http://ns.useplus.org/ldf/xmp/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dam="http://www.day.com/dam/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:mix="http://www.jcp.org/jcr/mix/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:isCheckedOut="{Boolean}true"
-    jcr:primaryType="dam:Asset"
-    jcr:uuid="b99941d2-091f-4100-be23-4da5b553f5ef">
+    jcr:primaryType="dam:Asset">
     <jcr:content
         cq:name="placeholder.pdf"
         cq:parentPath="/content/dam/asset-share-commons"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/resources/placeholder.pptx/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/resources/placeholder.pptx/.content.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:Iptc4xmpCore="http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/" xmlns:Iptc4xmpExt="http://iptc.org/std/Iptc4xmpExt/2008-02-29/" xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:xmpRights="http://ns.adobe.com/xap/1.0/rights/" xmlns:plus="http://ns.useplus.org/ldf/xmp/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dam="http://www.day.com/dam/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:mix="http://www.jcp.org/jcr/mix/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="dam:Asset"
-    jcr:uuid="4feab790-0047-407b-ab25-1d1d4a39f4f7">
+    jcr:primaryType="dam:Asset">
     <jcr:content
         dam:assetState="processed"
         dam:relativePath="asset-share-commons/placeholder.pptx"


### PR DESCRIPTION
Issue details: #189
@godanny86 , my bad i missed it, please review and merge. I have validated by installing on both 6.3 and 6.4 latest.