### PR TITLE
Feature/195 - IE11 JS incompatabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- 0195 - Search does not work in IE11 - Missing findIndex() & find() methods.
+
 ## [v1.5.0]
 
 ### Added

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/form-data.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/form-data.js
@@ -27,6 +27,30 @@ AssetShare.FormData = function (formEl) {
         form = $(formEl).serializeArray();
     }
 
+    /* IE polyfills for findIndex() and find() */
+
+    function findIndex(key) {
+        var i;
+
+        for (i = 0; i < form.length; ++i) {
+            if (form[i].name === key) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    function find(key) {
+       var index = findIndex(key);
+
+       if (index > -1) {
+           return form[index];
+       }
+
+       return null;
+    }
+
     function forEach(fn) {
         form.forEach(function (element) {
             fn(element.name, element.value);
@@ -42,18 +66,16 @@ AssetShare.FormData = function (formEl) {
     }
 
     function get(key) {
-        var element = form.find(function (element) {
-            return element.name === key;
-        });
+        var element = find(key);
+
         if (element) {
             return element.value;
         }
     }
 
     function remove(key) {
-        var index = form.findIndex(function (element) {
-            return element.name === key;
-        });
+        var index = findIndex(key);
+
         if (index > -1) {
             form.splice(index, 1);
         }


### PR DESCRIPTION
Fixes 195 - Search does not work in IE11 - replaced findIndex() & find() methods with polyfill methods.
