### PR TITLE
Issue#204: For mobile and tablet view, the filter rail should slide from left

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/root/clientlibs/editor/css/rail.less
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/root/clientlibs/editor/css/rail.less
@@ -24,4 +24,18 @@
     		width: 100% !important;
     		position: relative;
 	}
+	
+	@media only screen and (max-width: @tablet-max-width) {
+	 	#rail .ui.sidebar {
+	        width: 400px !important;
+	        position: fixed;
+ 		}
+	}
+	
+	@media only screen and (max-width: @mobile-max-width) {
+		 #rail .ui.sidebar {
+        	width: 350px !important;
+        	position: fixed;
+    	}
+	}
 }


### PR DESCRIPTION
Fix for Issue [#204 ](https://github.com/Adobe-Marketing-Cloud/asset-share-commons/issues/204)