### PR TITLE
#206 - Support asset details reference by Asset ID

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
@@ -168,14 +168,12 @@ public class EmailShareServiceImpl implements ShareService {
             if (assetResource != null && DamUtil.isAsset(assetResource)) {
                 final AssetModel asset = modelFactory.getModelFromWrappedRequest(config.getRequest(), assetResource, AssetModel.class);
 
-                String url = assetDetailsResolver.getUrl(config, asset);
+                String url = assetDetailsResolver.getFullUrl(config, asset);
 
                 if (StringUtils.isBlank(url)) {
                     log.warn("Could not determine an Asset Details page path for asset at [ {} ]", assetPath);
                     continue;
                 }
-
-                url += asset.getPath();
 
                 if (isAuthor()) {
                     url = externalizer.authorLink(config.getResourceResolver(), url);

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/AssetDetails.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/AssetDetails.java
@@ -23,6 +23,14 @@ import org.osgi.annotation.versioning.ProviderType;
 
 @ProviderType
 public interface AssetDetails {
+    /**
+     * @return the url to the asset details page, but do NOT include the asset reference in the suffix.
+     */
     String getUrl();
+
+    /**
+     * @return the full asset details link including the asset reference as the suffix.
+     */
+    default String getFullUrl() { return null; }
 }
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/AssetDetailsResolver.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/AssetDetailsResolver.java
@@ -24,5 +24,13 @@ import org.osgi.annotation.versioning.ProviderType;
 
 @ProviderType
 public interface AssetDetailsResolver {
+    /**
+     * @return the url to the asset details page, but do NOT include the asset reference in the suffix.
+     */
     String getUrl(final Config config, final AssetModel asset);
+
+    /**
+     * @return the full asset details link including the asset reference as the suffix.
+     */
+    default String getFullUrl(final Config config, final AssetModel asset) { return null; }
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/Config.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/Config.java
@@ -76,6 +76,11 @@ public interface Config {
     String getAssetDetailsUrl();
 
     /**
+     * @return true if the asset details pages should reference assets by path (else ID).
+     */
+    default boolean getAssetDetailReferenceById() { return true; }
+
+    /**
      * @return the path segment of the URL to call to render the Cart.
      */
     String getCartActionUrl();

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/AssetDetailsImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/AssetDetailsImpl.java
@@ -62,4 +62,17 @@ public class AssetDetailsImpl implements AssetDetails {
 
         return url;
     }
+
+    @Override
+    public String getFullUrl() {
+        String fullUrl = getUrl();
+
+        if (config.getAssetDetailReferenceById()) {
+            fullUrl += "/" + asset.getAssetId() + ".html";
+        } else {
+            fullUrl += asset.getPath();
+        }
+
+        return fullUrl;
+    }
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/AssetDetailsResolverImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/AssetDetailsResolverImpl.java
@@ -69,6 +69,20 @@ public class AssetDetailsResolverImpl implements AssetDetailsResolver {
         return url;
     }
 
+    public String getFullUrl(final Config config, final AssetModel asset) {
+        String fullUrl = getUrl(config, asset);
+
+        if (StringUtils.isNotBlank(fullUrl)) {
+            if (config.getAssetDetailReferenceById()) {
+                fullUrl += "/" + asset.getAssetId() + ".html";
+            } else {
+                fullUrl += asset.getPath();
+            }
+        }
+
+        return fullUrl;
+    }
+
     protected final void bindAssetDetailsSelector(final AssetDetailsSelector service, final Map<Object, Object> props) {
         final String type = service.getClass().getName();
         if (type != null) {

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/ConfigImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/ConfigImpl.java
@@ -84,6 +84,7 @@ public class ConfigImpl implements Config {
     private static final String PN_DEFAULT_ASSET_DETAILS_PATH = "config/asset-details/defaultPath";
     private static final String PN_ASSET_DETAILS_SELECTOR = "config/asset-details/selector";
     public static final String PN_PLACEHOLDER_ASSET_PATH = "config/asset-details/placeholderPath";
+    public static final String PN_ASSET_REFERENCE_BY_ID = "config/asset-details/assetReferenceById";
     public static final String DEFAULT_PLACEHOLDER_ASSET_PATH = "/apps/asset-share-commons/resources/placeholder.png";
 
     @Self
@@ -212,6 +213,12 @@ public class ConfigImpl implements Config {
     public String getAssetDetailsSelector() {
         return properties.get(PN_ASSET_DETAILS_SELECTOR, AlwaysUseDefaultSelectorImpl.ID);
     }
+
+    @Override
+    public boolean getAssetDetailReferenceById()  {
+        return properties.get(PN_ASSET_REFERENCE_BY_ID, false);
+    }
+
 
     @Override
     public String getAssetDetailsPath() {

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("1.1.0")
+@Version("1.2.0")
 package com.adobe.aem.commons.assetshare.configuration;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/AssetResolverImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/AssetResolverImpl.java
@@ -23,12 +23,17 @@ import com.adobe.aem.commons.assetshare.configuration.Config;
 import com.adobe.aem.commons.assetshare.content.AssetModel;
 import com.adobe.aem.commons.assetshare.content.AssetResolver;
 import com.day.cq.dam.api.Asset;
+import com.day.cq.dam.api.DamConstants;
+import com.day.cq.dam.commons.util.DamUtil;
 import com.day.cq.wcm.api.WCMMode;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.jcr.RepositoryException;
 
 @Component
 public class AssetResolverImpl implements AssetResolver {
@@ -37,9 +42,20 @@ public class AssetResolverImpl implements AssetResolver {
     public Asset resolveAsset(final SlingHttpServletRequest request) {
         Asset asset = null;
 
+        final String suffix = request.getRequestPathInfo().getSuffix();
         final Resource suffixResource = request.getRequestPathInfo().getSuffixResource();
         if (suffixResource != null) {
             asset = suffixResource.adaptTo(Asset.class);
+        } else if (StringUtils.isNotBlank(suffix) && !StringUtils.startsWith(suffix, DamConstants.MOUNTPOINT_ASSETS)) {
+            final String id = StringUtils.substringBefore(StringUtils.removeStart(suffix, "/"), ".");
+
+            if (StringUtils.isNotBlank(id)) {
+                try {
+                    asset = DamUtil.getAssetFromID(request.getResourceResolver(), id);
+                } catch (RepositoryException e) {
+                    log.error("Error attempting to resolve asset via id [ " + id + " ]", e);
+                }
+            }
         }
 
         if (asset == null) {

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/AssetResolverImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/AssetResolverImpl.java
@@ -44,18 +44,11 @@ public class AssetResolverImpl implements AssetResolver {
 
         final String suffix = request.getRequestPathInfo().getSuffix();
         final Resource suffixResource = request.getRequestPathInfo().getSuffixResource();
-        if (suffixResource != null) {
-            asset = suffixResource.adaptTo(Asset.class);
-        } else if (StringUtils.isNotBlank(suffix) && !StringUtils.startsWith(suffix, DamConstants.MOUNTPOINT_ASSETS)) {
-            final String id = StringUtils.substringBefore(StringUtils.removeStart(suffix, "/"), ".");
 
-            if (StringUtils.isNotBlank(id)) {
-                try {
-                    asset = DamUtil.getAssetFromID(request.getResourceResolver(), id);
-                } catch (RepositoryException e) {
-                    log.error("Error attempting to resolve asset via id [ " + id + " ]", e);
-                }
-            }
+        if (suffixResource != null) {
+            asset = getAssetByPath(suffixResource);
+        } else if (StringUtils.isNotBlank(suffix) && !StringUtils.startsWith(suffix, DamConstants.MOUNTPOINT_ASSETS)) {
+            asset = getAssetById(request, suffix);
         }
 
         if (asset == null) {
@@ -74,6 +67,23 @@ public class AssetResolverImpl implements AssetResolver {
         }
 
         return asset;
+    }
+
+    private Asset getAssetByPath(final Resource suffixResource) {
+        return suffixResource.adaptTo(Asset.class);
+    }
+
+    private Asset getAssetById(final SlingHttpServletRequest request, final String suffix) {
+        final String id = StringUtils.substringBefore(StringUtils.removeStart(suffix, "/"), ".");
+
+        if (StringUtils.isNotBlank(id)) {
+            try {
+                return DamUtil.getAssetFromID(request.getResourceResolver(), id);
+            } catch (RepositoryException e) {
+                log.error("Error attempting to resolve asset via ID [ " + id + " ]", e);
+            }
+        }
+        return null;
     }
 
     public Asset resolveAsset(final Resource assetResource) {

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/cart.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/cart.html
@@ -58,7 +58,7 @@
                 </td>
 
                 <td class="header">
-                    <a href="${assetDetails.url @ suffix = asset.path}">
+                    <a href="${assetDetails.fullUrl}">
                         ${asset.properties['title']}
                     </a>
                 </td>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/card/templates/card.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/card/templates/card.html
@@ -26,7 +26,7 @@
             id="${asset.path}"
             class="ui card cmp-card">
 
-        <a class="image cmp-image__wrapper--card" href="${assetDetails.url @ suffix = asset.path}">
+        <a class="image cmp-image__wrapper--card" href="${assetDetails.fullUrl}">
             <img src="${asset.properties['thumbnail'] || properties['missingImage'] @ context = 'attribute'}"
                  class="cmp-image--card"
                  alt="${asset.properties['title']}"/>
@@ -34,7 +34,7 @@
 
         <div class="content">
             <h3 class="header">
-                <a href="${assetDetails.url @ suffix = asset.path}">
+                <a href="${assetDetails.fullUrl}">
                     ${asset.properties['title']}
                 </a>
             </h3>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/list/templates/list.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/list/templates/list.html
@@ -39,10 +39,10 @@
 			id="${asset.path}">
 
 		<td class="image">
-			<a href="${assetDetails.url @ suffix = asset.path}"><img src="${asset.properties['thumbnail'] || properties['missingImage'] @ context = 'attribute'}" alt="${asset.properties['title']}"/></a>
+			<a href="${assetDetails.fullUrl}"><img src="${asset.properties['thumbnail'] || properties['missingImage'] @ context = 'attribute'}" alt="${asset.properties['title']}"/></a>
 		</td>
 		<td class="header">
-			<a href="${assetDetails.url @ suffix = asset.path}">${asset.properties['title']}</a>
+			<a href="${assetDetails.fullUrl}">${asset.properties['title']}</a>
 		</td>
 		<td>${'yyyy-MM-dd' @ format=asset.properties['jcr:content/jcr:lastModified'], locale=config.locale}</td>
 		<td>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/search-page/_cq_dialog/asset-share-commons/asset-details/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/search-page/_cq_dialog/asset-share-commons/asset-details/.content.xml
@@ -55,7 +55,7 @@
                                 rootPath="/content"
                                 required="true"/>
 
-                        <asset-details-asset-reference
+                        <asset-details-asset-reference-by-id
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
                                 text="Reference assets by ID"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/search-page/_cq_dialog/asset-share-commons/asset-details/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/search-page/_cq_dialog/asset-share-commons/asset-details/.content.xml
@@ -55,6 +55,15 @@
                                 rootPath="/content"
                                 required="true"/>
 
+                        <asset-details-asset-reference
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                text="Reference assets by ID"
+                                fieldDescription="Reference assets on asset details pages by ID, rather than path. When unchecked, the asset path is used."
+                                name="./config/asset-details/assetReferenceById"
+                                uncheckedValue="{Boolean}false"
+                                value="{Boolean}true"/>
+
                         <placeholder-asset-path
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1451868/42120783-392267a6-7bef-11e8-979c-2e3a4d38a3ef.png)

Handles links from search results and e-mail sharing. Does NOT tackle the cart (which still stores by path). Configurable via Page Properties...

![image](https://user-images.githubusercontent.com/1451868/42120790-57407a66-7bef-11e8-89bc-596280728c99.png)
