### PR TITLE
display download options when presets not empty

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download-dynamic-media/download-dynamic-media.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download-dynamic-media/download-dynamic-media.html
@@ -80,7 +80,7 @@
 
             <div class="field">
                 <select class="ui dropdown search" name="s7exportsettings"
-                        data-sly-test="${download.imagePresets.size == 0}">
+                        data-sly-test="${download.imagePresets.size != 0}">
                     <option value="">${properties.imagePresetsPlaceholderText}</option>
                     <sly data-sly-list.imagePreset="${download.imagePresets}">
                         <option value="{imagepreset:${imagePreset}}">${imagePreset}</option>


### PR DESCRIPTION
Fix the test to display download options or not in the download-dynamic-media component.