### PR TITLE
Feature/237 - Cart stops working after Download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- 0237: Fixes issue with ContextHub being unloaded after a Form submissions via modals.
+
 ## [v1.6.2]
 
 ### Changed

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/cart.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/cart.html
@@ -28,7 +28,7 @@
     }
 </style>
 
-<form method="get"
+<form method="post"
       action="${currentPage.path}.assetdownload.zip/Cart.zip"
       data-asset-share-id="cart"
       data-asset-share-id="cart-modal"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
@@ -29,6 +29,7 @@
 
 <form method="post"
       action="/content/dam.assetdownload.zip/${download.zipFileName}.zip"
+      target="download"
       data-asset-share-id="download-modal"
       class="ui modal cmp-modal-download--wrapper cmp-modal">
 


### PR DESCRIPTION
Sets the FORM action to target a new window (by default it targets _self). 
When _self is targeted, the FORM POST HTTP request triggers a window unload event, which ContextHub listens for and destroys the ContextHub object.

This fix introduces a "flicker" in as a new tab is opened and immediately closed, but the cart continues to work. This may be suboptimal if the download takes minutes to collect and download, as i believe the empty tab will display until the HTTP response headers are received.