### PR TITLE
#239 - Safely merge HTTP QB params and server-side QB params avoiding…

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PagePredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PagePredicateImpl.java
@@ -188,7 +188,7 @@ public class PagePredicateImpl extends AbstractPredicate implements PagePredicat
 
     @Override
     public PredicateGroup getPredicateGroup(ParamTypes... excludeParamTypes) {
-        final PredicateGroup root = new PredicateGroup("root");
+        final PredicateGroup root = new PredicateGroup();
         final PredicateGroup parameterGroup = new PredicateGroup(PredicateConverter.GROUP_PARAMETER_PREFIX);
 
         // Type Predicate
@@ -274,7 +274,7 @@ public class PagePredicateImpl extends AbstractPredicate implements PagePredicat
     }
 
     private void addTypeAsPredicateGroup(final PredicateGroup root) {
-        root.addAll(PredicateConverter.createPredicates(ImmutableMap.<String, String>builder().
+        root.add(PredicateConverter.createPredicates(ImmutableMap.<String, String>builder().
                 put(TypePredicateEvaluator.TYPE,  DamConstants.NT_DAM_ASSET).
                 build()));
     }


### PR DESCRIPTION
… group collisions

This should be a fix to the issue with QB Group collisions (and mergers)... there are some nuances with how QB tracks Group Ids in in the PredicateGroup objects.... which is a mix of specified group Ids, and the the index in an internal predicates array (and they might not always match!)

This issue can be worked around, by preferring the Predicate/Group Java APIs, removing any previously computed Predicate Names (ie. x_group) and then merging those nameless Predicates into an existing Predicate group, at which point, the nameless predicates will be given a non-conflicting name (ie. group). The exception to this, is the special "p" group, which we need merge together (which should be fine).

In this impl, server-side params are merged into the http Params, in an attempt to preserve the HTTP params' group Ids (mostly for debugging)...  when combining the query params (http and server) the server will likely get assigned a group that maps to an unused widget (ie if 3_group is the last http group, then the first server side group will be auto-computed to 4_group).