### PR TITLE
#223 - Fixed URLs used for requesting asset thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 0227: Sites editor is missing workflow status information
 - 0237: Fixes issue with ContextHub being unloaded after a Form submissions via modals.
 - 0240: Fixed issue with submitted date-range search values lagging behind actual value by one submission.
-
+- 0223: Fixed issue with the Thumbnail Computed Property generating URLs directly to the asset rendition for thumbnails, instead of using the OOTB "thumb" servlet.
 ## [v1.6.2]
 
 ### Changed

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/properties/impl/ThumbnailImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/properties/impl/ThumbnailImpl.java
@@ -34,7 +34,7 @@ public class ThumbnailImpl extends AbstractComputedProperty<String> {
     public static final String LABEL = "Thumbnail Rendition";
     public static final String NAME = "thumbnail";
 
-    private static final String THUMBNAIL_RENDITION_NAME = "cq5dam.thumbnail.319.319.png";
+    private static final String THUMBNAIL_RENDITION_SELECTOR = ".thumb.319.319.png";
 
     private Cfg cfg;
 
@@ -60,18 +60,7 @@ public class ThumbnailImpl extends AbstractComputedProperty<String> {
 
     @Override
     public String get(final Asset asset) {
-        Rendition rendition = asset.getRendition(THUMBNAIL_RENDITION_NAME);
-
-        if (rendition == null && asset.getImagePreviewRendition() != null) {
-            rendition = asset.getImagePreviewRendition();
-        }
-
-        // Ensure the rendition is of mime/type image; else the thumbnail will not be able to render
-        if (rendition != null && StringUtils.startsWith(rendition.getMimeType(), "image/")) {
-            return StringUtils.replace(rendition.getPath(), " ", "%20");
-        }
-
-        return "";
+        return StringUtils.replace(asset.getPath(), " ", "%20") + THUMBNAIL_RENDITION_SELECTOR;
     }
 
     @Activate


### PR DESCRIPTION
Uses the OOTB asset thumbnail servlet (with all its natural fallbacks) instead of direct links to rendition resources per @kaushalmall's suggestion.