### PR TITLE
#249 - Search Model cache issues

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PagePredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PagePredicateImpl.java
@@ -82,8 +82,6 @@ public class PagePredicateImpl extends AbstractPredicate implements PagePredicat
     @PostConstruct
     protected void init() {
         initPredicate(request, null);
-        //resource = searchConfig.getSearchResource();
-        //properties = resource.getValueMap();
     }
 
     @Override

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PagePredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PagePredicateImpl.java
@@ -22,6 +22,7 @@ package com.adobe.aem.commons.assetshare.components.predicates.impl;
 import com.adobe.aem.commons.assetshare.components.predicates.AbstractPredicate;
 import com.adobe.aem.commons.assetshare.components.predicates.HiddenPredicate;
 import com.adobe.aem.commons.assetshare.components.predicates.PagePredicate;
+import com.adobe.aem.commons.assetshare.components.search.SearchConfig;
 import com.adobe.aem.commons.assetshare.search.searchpredicates.SearchPredicate;
 import com.adobe.aem.commons.assetshare.util.ComponentModelVisitor;
 import com.adobe.aem.commons.assetshare.util.PredicateUtil;
@@ -37,14 +38,11 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.request.RequestParameter;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Required;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.Self;
-import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.factory.ModelFactory;
 
 import javax.annotation.PostConstruct;
@@ -60,19 +58,8 @@ import java.util.*;
 public class PagePredicateImpl extends AbstractPredicate implements PagePredicate {
     protected static final String RESOURCE_TYPE = "asset-share-commons/components/search/results";
 
-    private static final int MAX_GUESS_TOTAL = 2000;
     private static final int MAX_LIMIT = 1000;
     private static final int DEFAULT_LIMIT = 50;
-    private static final String DEFAULT_GUESS_TOTAL = "250";
-    private static final String DEFAULT_ORDER_BY = "@jcr:score";
-    private static final String DEFAULT_ORDER_BY_SORT = "desc";
-    private final String[] DEFAULT_PATHS = {"/content/dam"};
-
-    private String PN_ORDERBY = "orderBy";
-    private String PN_ORDERBY_SORT = "orderBySort";
-    private String PN_LIMIT = "limit";
-    private String PN_PATHS = "paths";
-    private String PN_SEARCH_PREDICATES = "searchPredicates";
 
     @Self
     @Required
@@ -82,9 +69,9 @@ public class PagePredicateImpl extends AbstractPredicate implements PagePredicat
     @Required
     private Page currentPage;
 
-    @SlingObject
+    @Self
     @Required
-    private Resource resource;
+    private SearchConfig searchConfig;
 
     @OSGiService
     private ModelFactory modelFactory;
@@ -92,12 +79,11 @@ public class PagePredicateImpl extends AbstractPredicate implements PagePredicat
     @OSGiService
     private List<SearchPredicate> searchPredicates;
 
-    private ValueMap properties;
-
     @PostConstruct
     protected void init() {
         initPredicate(request, null);
-        properties = resource.getValueMap();
+        //resource = searchConfig.getSearchResource();
+        //properties = resource.getValueMap();
     }
 
     @Override
@@ -113,12 +99,12 @@ public class PagePredicateImpl extends AbstractPredicate implements PagePredicat
 
     public String getOrderBy() {
         final String value = PredicateUtil.getParamFromQueryParams(request, "orderby");
-        return StringUtils.defaultIfBlank(value, properties.get(PN_ORDERBY, DEFAULT_ORDER_BY));
+        return StringUtils.defaultIfBlank(value, searchConfig.getOrderBy());
     }
 
     public String getOrderBySort() {
         final String value = PredicateUtil.getParamFromQueryParams(request, "orderby.sort");
-        return StringUtils.defaultIfBlank(value, properties.get(PN_ORDERBY_SORT, DEFAULT_ORDER_BY_SORT));
+        return StringUtils.defaultIfBlank(value, searchConfig.getOrderBySort());
     }
 
     public int getLimit() {
@@ -129,10 +115,10 @@ public class PagePredicateImpl extends AbstractPredicate implements PagePredicat
             try {
                 limit = Integer.parseInt(requestParameter.getString());
             } catch (NumberFormatException e) {
-                limit = properties.get(PN_LIMIT, DEFAULT_LIMIT);
+                limit = searchConfig.getLimit();
             }
         } else {
-            limit = properties.get(PN_LIMIT, DEFAULT_LIMIT);
+            limit = searchConfig.getLimit();
         }
 
         if (limit > MAX_LIMIT) {
@@ -145,40 +131,11 @@ public class PagePredicateImpl extends AbstractPredicate implements PagePredicat
     }
 
     public String getGuessTotal() {
-        final String guessTotal = properties.get(Predicate.PARAM_GUESS_TOTAL, DEFAULT_GUESS_TOTAL);
-
-        if ("true".equalsIgnoreCase(guessTotal)) {
-            return guessTotal;
-        } else {
-            try {
-                int tmp = Integer.parseInt(guessTotal);
-
-                if (tmp < 1 || tmp > MAX_GUESS_TOTAL) {
-                    return DEFAULT_GUESS_TOTAL;
-                } else {
-                    return String.valueOf(tmp);
-                }
-            } catch (NumberFormatException e) {
-                return DEFAULT_GUESS_TOTAL;
-            }
-        }
+        return searchConfig.getGuessTotal();
     }
 
     public List<String> getPaths() {
-        final String[] uncheckedPaths = properties.get(PN_PATHS, DEFAULT_PATHS);
-        final List<String> paths = new ArrayList<>();
-
-        for (final String path : uncheckedPaths) {
-            if (StringUtils.equals(path, DamConstants.MOUNTPOINT_ASSETS) || StringUtils.startsWith(path, DamConstants.MOUNTPOINT_ASSETS)) {
-                paths.add(path);
-            }
-        }
-
-        if (paths.size() < 1) {
-            return Arrays.asList(DEFAULT_PATHS);
-        } else {
-            return paths;
-        }
+        return searchConfig.getPaths();
     }
 
     @Override
@@ -230,13 +187,13 @@ public class PagePredicateImpl extends AbstractPredicate implements PagePredicat
 
     private void addGuessTotalAsParameterPredicate(final PredicateGroup parameterGroup) {
         parameterGroup.addAll(PredicateConverter.createPredicates(ImmutableMap.<String, String>builder().
-                put(Predicate.PARAM_GUESS_TOTAL,  getGuessTotal()).
+                put(Predicate.PARAM_GUESS_TOTAL, getGuessTotal()).
                 build()));
     }
 
     private void addLimitAsParameterPredicate(final PredicateGroup parameterGroup) {
         parameterGroup.addAll(PredicateConverter.createPredicates(ImmutableMap.<String, String>builder().
-                put(Predicate.PARAM_LIMIT,  String.valueOf(getLimit())).
+                put(Predicate.PARAM_LIMIT, String.valueOf(getLimit())).
                 build()));
     }
 
@@ -275,12 +232,12 @@ public class PagePredicateImpl extends AbstractPredicate implements PagePredicat
 
     private void addTypeAsPredicate(final PredicateGroup root) {
         root.addAll(PredicateConverter.createPredicates(ImmutableMap.<String, String>builder().
-                put(TypePredicateEvaluator.TYPE,  DamConstants.NT_DAM_ASSET).
+                put(TypePredicateEvaluator.TYPE, DamConstants.NT_DAM_ASSET).
                 build()));
     }
 
-    private  List<SearchPredicate> getSearchPredicates() {
-        final List<String> searchPredicateNames = Arrays.asList(properties.get(PN_SEARCH_PREDICATES, new String[]{}));
+    private List<SearchPredicate> getSearchPredicates() {
+        final List<String> searchPredicateNames = searchConfig.getSearchPredicatesNames();
         final List<SearchPredicate> matchingSearchPredicates = new ArrayList<>();
 
         for (String searchPredicateName : searchPredicateNames) {
@@ -303,7 +260,9 @@ public class PagePredicateImpl extends AbstractPredicate implements PagePredicat
         return visitor.getModels();
     }
 
-    /** Deprecated Methods **/
+    /**
+     * Deprecated Methods
+     **/
 
     @Override
     @Deprecated

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/SearchConfig.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/SearchConfig.java
@@ -1,0 +1,77 @@
+package com.adobe.aem.commons.assetshare.components.search;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.osgi.annotation.versioning.ProviderType;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Class that represents the overarching Search configuration that may span across components.
+ *
+ * These methods return the default values set by the Search Results component itself.
+ *
+ * This class should not take into account HTTP-provided parameters, but rather deal directly with the resource content.
+ */
+@ProviderType
+public interface SearchConfig {
+    /**
+     * @return the resource that represents the Search Component resource.
+     */
+    default Resource getSearchResource() { return  null; }
+
+    /**
+     * @return a value map for the search results component.
+     */
+    ValueMap getProperties();
+
+    /**
+     * The mode derived from the request and if unavailable, then from the configured component state.
+     *
+     * @return the active search mode (ex. search, browse).
+     */
+    String getMode();
+
+    /**
+     * The layout derived from the request and if unavailable, then from the configured component state.
+     *
+     * @return the active layout mode (ex. card, list)
+     */
+    String getLayout();
+
+    /**
+     * @return a list of the paths that are eligible for searching.
+     */
+    List<String> getPaths();
+
+    /**
+     * @return the active order by property value.
+     */
+    String getOrderBy();
+
+    /**
+     * @return the active order by sort direction.
+     */
+    String getOrderBySort();
+
+    /**
+     * @return the limit of number of results to return for this search.
+     */
+    int getLimit();
+
+    /**
+     * @return the configured Guess Total.
+     */
+    String getGuessTotal();
+
+    /**
+     * @return the default
+     */
+    String getSearchProviderId();
+
+    /**
+     * @return a list of search predicate names, as configured on the search results component.
+     */
+    default List<String> getSearchPredicatesNames() { return Collections.EMPTY_LIST; }
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
@@ -20,6 +20,7 @@ import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
@@ -104,20 +105,15 @@ public class SearchConfigImpl implements SearchConfig {
     public String getGuessTotal() {
         final String guessTotal = properties.get(PN_GUESS_TOTAL, DEFAULT_GUESS_TOTAL);
 
-        if ("true".equalsIgnoreCase(guessTotal)) {
-            return guessTotal;
-        } else {
-            try {
-                int tmp = Integer.parseInt(guessTotal);
+        if (Boolean.TRUE.toString().equalsIgnoreCase(guessTotal)) {
+            return Boolean.TRUE.toString();
+        }
 
-                if (tmp < 1 || tmp > MAX_GUESS_TOTAL) {
-                    return DEFAULT_GUESS_TOTAL;
-                } else {
-                    return String.valueOf(tmp);
-                }
-            } catch (NumberFormatException e) {
-                return DEFAULT_GUESS_TOTAL;
-            }
+        try {
+            int guessTotalAsNumber = Integer.parseInt(guessTotal);
+            return (guessTotalAsNumber < 1 || guessTotalAsNumber > MAX_GUESS_TOTAL) ? DEFAULT_GUESS_TOTAL : String.valueOf(guessTotalAsNumber);
+        } catch (NumberFormatException e) {
+            return DEFAULT_GUESS_TOTAL;
         }
     }
 
@@ -143,20 +139,11 @@ public class SearchConfigImpl implements SearchConfig {
 
     @Override
     public List<String> getPaths() {
-        final String[] uncheckedPaths = properties.get(PN_PATHS, DEFAULT_PATHS);
-        final List<String> paths = new ArrayList<>();
+        final List<String> paths  = Arrays.stream(properties.get(PN_PATHS, DEFAULT_PATHS)).filter(path ->
+          StringUtils.equals(path, DamConstants.MOUNTPOINT_ASSETS) || StringUtils.startsWith(path, DamConstants.MOUNTPOINT_ASSETS)
+        ).collect(Collectors.toList());
 
-        for (final String path : uncheckedPaths) {
-            if (StringUtils.equals(path, DamConstants.MOUNTPOINT_ASSETS) || StringUtils.startsWith(path, DamConstants.MOUNTPOINT_ASSETS)) {
-                paths.add(path);
-            }
-        }
-
-        if (paths.size() < 1) {
-            return Arrays.asList(DEFAULT_PATHS);
-        } else {
-            return paths;
-        }
+        return (paths.size() < 1) ? Arrays.asList(DEFAULT_PATHS) : paths;
     }
 
     @Override

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
@@ -1,0 +1,166 @@
+package com.adobe.aem.commons.assetshare.components.search.impl;
+
+import com.adobe.aem.commons.assetshare.components.search.SearchConfig;
+import com.adobe.aem.commons.assetshare.util.ResourceTypeVisitor;
+import com.day.cq.dam.api.DamConstants;
+import com.day.cq.search.Predicate;
+import com.day.cq.wcm.api.Page;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.Optional;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.models.factory.ModelFactory;
+
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Model(
+        adaptables = {SlingHttpServletRequest.class},
+        adapters = {SearchConfig.class},
+        resourceType = {SearchConfigImpl.RESOURCE_TYPE}
+)
+public class SearchConfigImpl implements SearchConfig {
+    public static final String RESOURCE_TYPE = "asset-share-commons/components/search/results";
+
+    private static final int MAX_GUESS_TOTAL = 2000;
+    private static final int DEFAULT_LIMIT = 50;
+
+    private static final String DEFAULT_GUESS_TOTAL = "250";
+    private static final String DEFAULT_ORDER_BY = "@jcr:score";
+    private static final String DEFAULT_ORDER_BY_SORT = Predicate.SORT_DESCENDING;
+    private static final String DEFAULT_LAYOUT = "card";
+    private static final String DEFAULT_SPID = "search";
+
+    private final String[] DEFAULT_PATHS = {"/content/dam"};
+
+    private String PN_ORDER_BY = "orderBy";
+    private String PN_ORDER_BY_SORT = "orderBySort";
+    private String PN_LIMIT = Predicate.PARAM_LIMIT;
+    private String PN_PATHS = "paths";
+    private String PN_LAYOUT = "layout";
+    private String PN_GUESS_TOTAL = Predicate.PARAM_GUESS_TOTAL;
+    private String PN_SPID = "searchProviderId";
+    private String PN_SEARCH_PREDICATES = "searchPredicates";
+
+    @Self
+    private SlingHttpServletRequest request;
+
+    @ScriptVariable
+    private Page currentPage;
+
+    @OSGiService
+    private ModelFactory modelFactory;
+
+    @Self
+    @Optional
+    private Resource resource;
+
+    private ValueMap properties;
+
+    List<String> paths;
+
+    @PostConstruct
+    protected void init() {
+        if (resource == null || !resource.isResourceType(RESOURCE_TYPE)) {
+
+            final ResourceTypeVisitor visitor = new ResourceTypeVisitor(new String[]{RESOURCE_TYPE});
+            visitor.accept(currentPage.getContentResource());
+
+            if (visitor.getResources().size() > 0) {
+                resource = visitor.getResources().iterator().next();
+            }
+        }
+
+        if (resource == null) {
+            throw new IllegalArgumentException("Adaptable must resolve a search results component.");
+        }
+
+        properties = resource.getValueMap();
+    }
+
+    @Override
+    public ValueMap getProperties() {
+        return properties;
+    }
+
+    @Override
+    public String getMode() {
+        return properties.get(PN_SPID, DEFAULT_SPID);
+    }
+
+    @Override
+    public String getLayout() {
+        return properties.get(PN_LAYOUT, DEFAULT_LAYOUT);
+
+    }
+    @Override
+    public String getGuessTotal() {
+        final String guessTotal = properties.get(PN_GUESS_TOTAL, DEFAULT_GUESS_TOTAL);
+
+        if ("true".equalsIgnoreCase(guessTotal)) {
+            return guessTotal;
+        } else {
+            try {
+                int tmp = Integer.parseInt(guessTotal);
+
+                if (tmp < 1 || tmp > MAX_GUESS_TOTAL) {
+                    return DEFAULT_GUESS_TOTAL;
+                } else {
+                    return String.valueOf(tmp);
+                }
+            } catch (NumberFormatException e) {
+                return DEFAULT_GUESS_TOTAL;
+            }
+        }
+    }
+
+    @Override
+    public String getSearchProviderId() {
+        return properties.get(PN_SPID, DEFAULT_SPID);
+    }
+
+    @Override
+    public int getLimit() {
+        return properties.get(PN_LIMIT, DEFAULT_LIMIT);
+    }
+
+    @Override
+    public String getOrderBy() {
+        return properties.get(PN_ORDER_BY, DEFAULT_ORDER_BY);
+    }
+
+    @Override
+    public String getOrderBySort() {
+        return properties.get(PN_ORDER_BY_SORT, DEFAULT_ORDER_BY_SORT);
+    }
+
+    @Override
+    public List<String> getPaths() {
+        final String[] uncheckedPaths = properties.get(PN_PATHS, DEFAULT_PATHS);
+        final List<String> paths = new ArrayList<>();
+
+        for (final String path : uncheckedPaths) {
+            if (StringUtils.equals(path, DamConstants.MOUNTPOINT_ASSETS) || StringUtils.startsWith(path, DamConstants.MOUNTPOINT_ASSETS)) {
+                paths.add(path);
+            }
+        }
+
+        if (paths.size() < 1) {
+            return Arrays.asList(DEFAULT_PATHS);
+        } else {
+            return paths;
+        }
+    }
+
+    @Override
+    public List<String> getSearchPredicatesNames() {
+        return Arrays.asList(properties.get(PN_SEARCH_PREDICATES, new String[]{}));
+    }
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("1.0.0")
+@Version("1.1.0")
 package com.adobe.aem.commons.assetshare.components.search;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/SearchImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/SearchImpl.java
@@ -19,6 +19,7 @@
 
 package com.adobe.aem.commons.assetshare.search.impl;
 
+import com.adobe.aem.commons.assetshare.components.search.SearchConfig;
 import com.adobe.aem.commons.assetshare.search.Constants;
 import com.adobe.aem.commons.assetshare.search.Search;
 import com.adobe.aem.commons.assetshare.search.UnsafeSearchException;
@@ -29,6 +30,7 @@ import com.adobe.aem.commons.assetshare.util.PredicateUtil;
 import com.day.cq.wcm.api.Page;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Required;
@@ -62,6 +64,10 @@ public class SearchImpl implements Search {
     @Required
     private SlingHttpServletRequest request;
 
+    @Self
+    @Required
+    private SearchConfig searchConfig;
+
     @ScriptVariable
     private Page currentPage;
 
@@ -70,8 +76,11 @@ public class SearchImpl implements Search {
     // Results component properties
     private ValueMap properties;
 
+    private Resource resource;
+
     @PostConstruct
     protected void init() {
+        resource = searchConfig.getSearchResource();
         properties = request.getResource().getValueMap();
     }
 


### PR DESCRIPTION
Updating models to do a better job of "finding" the correct resource(s) on the page that represent the Search component.

This allows Sling Models to be created from various resources, yet still "resolve" to the right resource (and get the appropriate properties) with the model instantiator not having to know which/how to find the right resource.