### PR TITLE
#267 - Reverting changes from #253 as case-insensitive sorting does n…

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/SearchConfig.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/SearchConfig.java
@@ -56,9 +56,11 @@ public interface SearchConfig {
     String getOrderBySort();
 
     /**
+     * Note that ordering case-insensitive with QueryBuilder breaks sorting by anything by text data, this it is inadvisable for this to return false unto this is fixed in AEM.
+     *
      * @return true if the sort order is case-sensitive, else false;
      */
-    default boolean isOrderByCase() { return false; }
+    default boolean isOrderByCase() { return true; }
 
     /**
      * @return the limit of number of results to return for this search.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
@@ -36,7 +36,7 @@ public class SearchConfigImpl implements SearchConfig {
     private static final String DEFAULT_GUESS_TOTAL = "250";
     private static final String DEFAULT_ORDER_BY = "@jcr:score";
     private static final String DEFAULT_ORDER_BY_SORT = Predicate.SORT_DESCENDING;
-    private static final boolean DEFAULT_ORDER_BY_CASE = false;
+    private static final boolean DEFAULT_ORDER_BY_CASE = true;
 
     private static final String DEFAULT_LAYOUT = "card";
     private static final String DEFAULT_SPID = "search";

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/_cq_dialog/.content.xml
@@ -123,15 +123,22 @@
                                         </items>
                                     </default-orderby-sort>
 
+                                    <!--
+                                    Commented per: https://github.com/Adobe-Marketing-Cloud/asset-share-commons/issues/267
+
+                                    This is pending a fix in AEM.
+
                                     <orderby-case
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:orderBefore="name"
-                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                            fieldDescription="Check this for case-sensitive sorting."
-                                            name="./orderByCase"
-                                            text="Case-sensitive Sorting"
-                                            value="{Boolean}true"
-                                            uncheckedValue="{Boolean}false"/>
+                                          jcr:primaryType="nt:unstructured"
+                                          sling:orderBefore="name"
+                                          sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                          fieldDescription="Check this for case-insensitive sorting."
+                                          name="./orderByCase"
+                                          text="Case-insensitive Sorting"
+                                          value="{Boolean}false"
+                                          uncheckedValue="{Boolean}true"/>
+                                    -->
+
                                 </items>
                             </column>
                         </items>


### PR DESCRIPTION
…ot work properly.

Removes the ability to toggle case sensitive/insensitive search as it only works for text values (and not numbers, dates) due to how QueryBuilder implements it. The guts of this is left intact so we can easily "enable" it if/when this is fixed in product.

/cc @Shaihuludus 