### PR TITLE
#275 - Revert Core Components dep from 2.1.0 to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,14 +192,14 @@
             <dependency>
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.core</artifactId>
-                <version>2.1.0</version>
+                <version>1.1.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.all</artifactId>
                 <type>zip</type>
-                <version>2.1.0</version>
+                <version>1.1.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/details-page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/details-page/_cq_dialog/.content.xml
@@ -23,7 +23,7 @@
           jcr:primaryType="nt:unstructured"
           jcr:title="Page"
           sling:resourceType="cq/gui/components/authoring/dialog"
-          extraClientlibs="[cq.common.wcm,core.wcm.components.page.v2.editor,cq.wcm.msm.properties]"
+          extraClientlibs="[cq.common.wcm,core.wcm.components.page.v1.editor,cq.wcm.msm.properties]"
           helpPath="https://www.adobe.com/go/aem_cmp_page_v1"
           mode="edit">
     <content

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/page/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/page/.content.xml
@@ -20,5 +20,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
           xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="cq:Component"
-          sling:resourceSuperType="core/wcm/components/page/v2/page"
+          sling:resourceSuperType="core/wcm/components/page/v1/page"
           componentGroup=".hidden"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/page/_cq_dialog/.content.xml
@@ -22,7 +22,7 @@
           jcr:title="Page"
           sling:resourceType="cq/gui/components/authoring/dialog"
           helpPath="https://www.adobe.com/go/aem_cmp_page_v1"
-          extraClientlibs="[cq.common.wcm,core.wcm.components.page.v2.editor,cq.wcm.msm.properties]"
+          extraClientlibs="[cq.common.wcm,core.wcm.components.page.v1.editor,cq.wcm.msm.properties]"
           mode="edit">
     <content
             granite:class="cq-dialog-content-page"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/search-page/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/search-page/_cq_dialog/.content.xml
@@ -23,7 +23,7 @@
           jcr:primaryType="nt:unstructured"
           jcr:title="Page"
           sling:resourceType="cq/gui/components/authoring/dialog"
-          extraClientlibs="[cq.common.wcm,core.wcm.components.page.v2.editor,cq.wcm.msm.properties]"
+          extraClientlibs="[cq.common.wcm,core.wcm.components.page.v1.editor,cq.wcm.msm.properties]"
           helpPath="https://www.adobe.com/go/aem_cmp_page_v1"
           mode="edit">
     <content


### PR DESCRIPTION
This unfortunately resurrects issue #192 ... 

we'll need another release that breaks backwards compat but includes this fix.