### PR TITLE
Feature/285

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ MANIFEST.MF
 .idea/
 *.iml
 
+#VS Code
+.vscode
+
 #gh-pages
 .sass-cache/
 _site

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/elements.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/elements.js
@@ -41,6 +41,13 @@ AssetShare.Elements = (function (document, $, ns) {
         return $(getAssetShareIdSelector(id), doc);
     }
 
+    function removeElementsByAssetShareId(id, doc) {
+        var element = $(getAssetShareIdSelector(id), doc);
+        if(element) {
+            $(element).remove();
+        }
+    }
+
     /*
     <div data-asset-share-id="foo"
          data-asset-share-update-method="append|replace|attribute"
@@ -97,7 +104,8 @@ AssetShare.Elements = (function (document, $, ns) {
     return {
         selector: getAssetShareIdSelector,
         element: getElementsByAssetShareId,
-        update: update
+        update: update,
+        remove: removeElementsByAssetShareId
     };
 }(document,
     jQuery,

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/modal.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/modal.js
@@ -66,6 +66,7 @@ AssetShare.SemanticUI.Modal = (function ($, ns) {
         var index = tracker.indexOf(id);
         if (index !== -1) {
             tracker.splice(index, 1);
+            ns.Elements.remove(id);
         }
     }
 


### PR DESCRIPTION
Fix for #285 

* Investigated Semantic UI modal and seems like default behavior is to leave the modal in the DOM, which I'm assuming is for performance reasons see https://github.com/Semantic-Org/Semantic-UI/issues/3200
* Simply removes the modal from the DOM as part of the onHidden event handler

I thought about attempting to manage the state so that we don't always destroy the modal by default and thus do not need to re-request the modal from the server. This would add complexity and would need to uniquely identify the modal based on the type and asset path(s) in order to re-initialize it client side. It might not be used that much since the modal divs are removed upon page navigation and it is rare that a modal is the same.