### PR TITLE
feature/290-modal-events

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/events.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/events.js
@@ -28,7 +28,9 @@ AssetShare.Events = {
 	PAGE_LOAD: "asset-share-commons.page.load",
 
     SEARCH_BEGIN: "asset-share-commons.search.begin",
-    SEARCH_END: "asset-share-commons.search.end"
+    SEARCH_END: "asset-share-commons.search.end",
+
+    MODAL_SHOWN: "asset-share-commons.modal.shown"
 };
 
 jQuery((function($, ns) {

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/modal.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/modal.js
@@ -96,6 +96,7 @@ AssetShare.SemanticUI.Modal = (function ($, ns) {
                             if (isPreviewMode()) {
                                 onShowModalInPreviewMode(this);
                             }
+                            $("body").trigger(ns.Events.MODAL_SHOWN);
                         },
                         onHidden: function() {
                             removeFromOpenModals(modal.id);


### PR DESCRIPTION
This small change gives us a possibility to run stuff after the modal is shown - it is useful for custom modals. For example now we can use this event to start SemanticUI functions on the modal.
