### PR TITLE
307/308 - Handle displaying images for non-image assets better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unrelease]
+- 0307: Fixed issue with Details page Image component's fallback is not used for non-image assets. 
+- 0308: Fixed issue where unsupported (by the browser) image asset types (ex. DFX) are used for image display in browser (thumbs/preview) instead of placeholder.
+
 ## [v1.6.9]
 
 ### Fixed
--0301: Files having special character in the filename. Download,Share and Add to Cart do not work.
+- 0301: Files having special character in the filename. Download,Share and Add to Cart do not work.
 
 ## [Unreleased]
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/ImageImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/ImageImpl.java
@@ -88,11 +88,10 @@ public class ImageImpl extends AbstractEmptyTextComponent implements Image {
                 final Pattern pattern = Pattern.compile(renditionRegex);
 
                 for (final Rendition rendition : asset.getRenditions()) {
-                    if (pattern.matcher(rendition.getName()).matches()) {
-                        if (mimeTypeHelper.isBrowserSupportedImage(rendition.getMimeType())) {
-                            src = rendition.getPath();
-                            break;
-                        }
+                    if (pattern.matcher(rendition.getName()).matches() &&
+                        mimeTypeHelper.isBrowserSupportedImage(rendition.getMimeType())) {
+                        src = rendition.getPath();
+                        break;
                     }
                 }
             }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/ImageImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/ImageImpl.java
@@ -21,17 +21,21 @@ package com.adobe.aem.commons.assetshare.components.details.impl;
 
 import com.adobe.aem.commons.assetshare.components.details.Image;
 import com.adobe.aem.commons.assetshare.content.AssetModel;
+import com.adobe.aem.commons.assetshare.util.MimeTypeHelper;
 import com.day.cq.dam.api.Rendition;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Required;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
 import javax.annotation.PostConstruct;
+import java.net.URLDecoder;
 import java.util.regex.Pattern;
 
 @Model(
@@ -50,6 +54,10 @@ public class ImageImpl extends AbstractEmptyTextComponent implements Image {
     @Self
     @Required
     private AssetModel asset;
+
+    @OSGiService
+    @Required
+    private MimeTypeHelper mimeTypeHelper;
 
     @ValueMapValue
     private String computedProperty;
@@ -81,8 +89,10 @@ public class ImageImpl extends AbstractEmptyTextComponent implements Image {
 
                 for (final Rendition rendition : asset.getRenditions()) {
                     if (pattern.matcher(rendition.getName()).matches()) {
-                        src = rendition.getPath();
-                        break;
+                        if (mimeTypeHelper.isBrowserSupportedImage(rendition.getMimeType())) {
+                            src = rendition.getPath();
+                            break;
+                        }
                     }
                 }
             }
@@ -99,6 +109,9 @@ public class ImageImpl extends AbstractEmptyTextComponent implements Image {
     public String getAlt() {
         return asset.getTitle();
     }
+
+    @Override
+    public String getFallback() { return fallbackSrc; }
 
     @Override
     public boolean isEmpty() {

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/package-info.java
@@ -14,7 +14,7 @@
  *
  */
 
-@Version("1.1.0")
+@Version("1.2.0")
 package com.adobe.aem.commons.assetshare.components.details;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
@@ -155,11 +155,12 @@ public class SearchConfigImpl implements SearchConfig {
     }
 
     private Resource resolveSearchConfigResource(final PageManager pageManager, final Resource currentResource) {
-        if (currentResource == null || !StringUtils.startsWith(resource.getPath(), "/content/")) {
+        if (currentResource == null || !StringUtils.startsWith(currentResource.getPath(), "/content/")) {
             // Hit the sites tree root; stop looking!
             return null;
         } else if (currentResource.isResourceType(RESOURCE_TYPE)) {
             // We won the powerball! this passed in resource is the right resource!
+            // Ok, not really the powerball, this happens when the Search Results component uses this model.
             return currentResource;
         } else {
             // Go look under each page, up the tree for the component.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
@@ -155,25 +155,30 @@ public class SearchConfigImpl implements SearchConfig {
     }
 
     private Resource resolveSearchConfigResource(final PageManager pageManager, final Resource currentResource) {
-        if (currentResource == null || !StringUtils.startsWith(currentResource.getPath(), "/content/")) {
+        if (!isValidResource(currentResource)) {
             // Hit the sites tree root; stop looking!
             return null;
         } else if (currentResource.isResourceType(RESOURCE_TYPE)) {
             // We won the powerball! this passed in resource is the right resource!
             // Ok, not really the powerball, this happens when the Search Results component uses this model.
             return currentResource;
-        } else {
-            // Go look under each page, up the tree for the component.
-            final ResourceTypeVisitor visitor = new ResourceTypeVisitor(new String[]{RESOURCE_TYPE});
-            final Page page = pageManager.getContainingPage(currentResource);
-
-            visitor.accept(page.getContentResource());
-
-            if (visitor.getResources().size() > 0) {
-                return visitor.getResources().iterator().next();
-            } else {
-                return resolveSearchConfigResource(pageManager, page.getParent().getContentResource());
-            }
         }
+
+        // Go look under each page, up the tree for the component.
+        final ResourceTypeVisitor visitor = new ResourceTypeVisitor(new String[]{RESOURCE_TYPE});
+        final Page page = pageManager.getContainingPage(currentResource);
+
+        visitor.accept(page.getContentResource());
+
+        if (visitor.getResources().size() > 0) {
+            return visitor.getResources().iterator().next();
+        } else {
+            return resolveSearchConfigResource(pageManager, page.getParent().getContentResource());
+        }
+    }
+
+
+    private boolean isValidResource(Resource resource) {
+        return resource != null && StringUtils.startsWith(resource.getPath(), "/content/");
     }
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
@@ -5,6 +5,7 @@ import com.adobe.aem.commons.assetshare.util.ResourceTypeVisitor;
 import com.day.cq.dam.api.DamConstants;
 import com.day.cq.search.Predicate;
 import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -73,15 +74,8 @@ public class SearchConfigImpl implements SearchConfig {
 
     @PostConstruct
     protected void init() {
-        if (resource == null || !resource.isResourceType(RESOURCE_TYPE)) {
-
-            final ResourceTypeVisitor visitor = new ResourceTypeVisitor(new String[]{RESOURCE_TYPE});
-            visitor.accept(currentPage.getContentResource());
-
-            if (visitor.getResources().size() > 0) {
-                resource = visitor.getResources().iterator().next();
-            }
-        }
+        resource = resolveSearchConfigResource(request.getResourceResolver().adaptTo(PageManager.class),
+                request.getResource());
 
         if (resource == null) {
             throw new IllegalArgumentException("Adaptable must resolve a search results component.");
@@ -103,7 +97,6 @@ public class SearchConfigImpl implements SearchConfig {
     @Override
     public String getLayout() {
         return properties.get(PN_LAYOUT, DEFAULT_LAYOUT);
-
     }
 
     @Override
@@ -159,5 +152,27 @@ public class SearchConfigImpl implements SearchConfig {
     @Override
     public List<String> getSearchPredicatesNames() {
         return Arrays.asList(properties.get(PN_SEARCH_PREDICATES, new String[]{}));
+    }
+
+    private Resource resolveSearchConfigResource(final PageManager pageManager, final Resource currentResource) {
+        if (currentResource == null || !StringUtils.startsWith(resource.getPath(), "/content/")) {
+            // Hit the sites tree root; stop looking!
+            return null;
+        } else if (currentResource.isResourceType(RESOURCE_TYPE)) {
+            // We won the powerball! this passed in resource is the right resource!
+            return currentResource;
+        } else {
+            // Go look under each page, up the tree for the component.
+            final ResourceTypeVisitor visitor = new ResourceTypeVisitor(new String[]{RESOURCE_TYPE});
+            final Page page = pageManager.getContainingPage(currentResource);
+
+            visitor.accept(page.getContentResource());
+
+            if (visitor.getResources().size() > 0) {
+                return visitor.getResources().iterator().next();
+            } else {
+                return resolveSearchConfigResource(pageManager, page.getParent().getContentResource());
+            }
+        }
     }
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/datasources/ComputedPropertiesDataSource.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/datasources/ComputedPropertiesDataSource.java
@@ -30,6 +30,7 @@ import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +57,7 @@ public class ComputedPropertiesDataSource extends SlingSafeMethodsServlet {
     @Reference
     private DataSourceBuilder dataSourceBuilder;
 
-    @Reference
+    @Reference(policyOption = ReferencePolicyOption.GREEDY)
     private transient Collection<ComputedProperty> computedProperties;
 
     @Override

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/properties/impl/ThumbnailImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/properties/impl/ThumbnailImpl.java
@@ -18,11 +18,13 @@ package com.adobe.aem.commons.assetshare.content.properties.impl;
 
 import com.adobe.aem.commons.assetshare.content.properties.AbstractComputedProperty;
 import com.adobe.aem.commons.assetshare.content.properties.ComputedProperty;
+import com.adobe.aem.commons.assetshare.util.MimeTypeHelper;
 import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.Rendition;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
@@ -37,6 +39,9 @@ public class ThumbnailImpl extends AbstractComputedProperty<String> {
     private static final String THUMBNAIL_RENDITION_NAME = "cq5dam.thumbnail.319.319.png";
 
     private Cfg cfg;
+
+    @Reference
+    private MimeTypeHelper mimeTypeHelper;
 
     @Override
     public String getName() {
@@ -67,8 +72,10 @@ public class ThumbnailImpl extends AbstractComputedProperty<String> {
         }
 
         // Ensure the rendition is of mime/type image; else the thumbnail will not be able to render
-        if (rendition != null && StringUtils.startsWith(rendition.getMimeType(), "image/")) {
-            return StringUtils.replace(rendition.getPath(), " ", "%20");
+        if (rendition != null && mimeTypeHelper.isBrowserSupportedImage(rendition.getMimeType())) {
+            String path = StringUtils.replace(rendition.getPath(), " ", "%20");
+            path = StringUtils.replace(path, "/jcr:content", "/_jcr_content");
+            return path;
         }
 
         return "";

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/properties/impl/WebRenditionImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/properties/impl/WebRenditionImpl.java
@@ -68,18 +68,20 @@ public class WebRenditionImpl extends AbstractComputedProperty<String> {
         final Rendition rendition = DamUtil.getBestFitRendition(1280, asset.getRenditions());
         String path = "";
 
-        if (rendition != null && mimeTypeHelper.isBrowserSupportedImage(rendition.getMimeType())) {
+        if (rendition != null &&
+                mimeTypeHelper.isBrowserSupportedImage(rendition.getMimeType())) {
             path = rendition.getPath();
-        } else {
-            if (asset.getOriginal() != null && mimeTypeHelper.isBrowserSupportedImage(asset.getOriginal().getMimeType())) {
-                path = asset.getOriginal().getPath();
-            }
+        } else if (asset.getOriginal() != null &&
+                mimeTypeHelper.isBrowserSupportedImage(asset.getOriginal().getMimeType())) {
+            path = asset.getOriginal().getPath();
         }
 
-        path = StringUtils.replace(path, " ", "%20");
-        path = StringUtils.replace(path, "/jcr:content", "/_jcr_content");
+        return escapeString(path);
+    }
 
-        return path;
+    private String escapeString(String str) {
+        str = StringUtils.replace(str, " ", "%20");
+        return StringUtils.replace(str, "/jcr:content", "/_jcr_content");
     }
 
     @Activate

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/MimeTypeHelper.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/MimeTypeHelper.java
@@ -1,0 +1,13 @@
+package com.adobe.aem.commons.assetshare.util;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+@ProviderType
+public interface MimeTypeHelper {
+    /**
+     * @param mimeType the mime type to check
+     * @return true if the mime type is to be considered supported by the browser.
+     */
+    boolean isBrowserSupportedImage(String mimeType);
+
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/MimeTypeHelperImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/MimeTypeHelperImpl.java
@@ -1,0 +1,53 @@
+package com.adobe.aem.commons.assetshare.util.impl;
+
+import com.adobe.aem.commons.assetshare.util.MimeTypeHelper;
+import org.apache.commons.lang3.StringUtils;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+import java.util.Arrays;
+
+@Component(service = MimeTypeHelper.class)
+@Designate(ocd = MimeTypeHelperImpl.Cfg.class)
+public class MimeTypeHelperImpl implements MimeTypeHelper {
+
+    private Cfg cfg;
+
+    public boolean isBrowserSupportedImage(String mimeType) {
+        return Arrays.stream(cfg.browserSupportedImageMimeTypes()).anyMatch(browserSupportedImageMimeType -> {
+           return StringUtils.equals(browserSupportedImageMimeType, mimeType);
+        });
+    }
+
+    @Activate
+    protected void activate(Cfg cfg) {
+        this.cfg = cfg;
+    }
+
+    @ObjectClassDefinition(name = "Asset Share Commons - MimeTypeHelper")
+    public @interface Cfg {
+
+        @AttributeDefinition(
+                name = "Browser Supported Image MIME Types",
+                description = "List of MIME types that are considered images supported by the browser (can be displayed via img tag)."
+        )
+
+        // Default list taken from: https://en.wikipedia.org/wiki/Comparison_of_web_browsers#Image_format_support
+        String[] browserSupportedImageMimeTypes() default {
+                "image/jpg",
+                "image/jpeg",
+                "image/png",
+                "image/apng",
+                "image/gif",
+                "image/webp",
+                "image/tiff",
+                "image/svg+xml",
+                "image/bmp",
+                "image/x-xbitmap"
+        };
+    }
+
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("1.4.0")
+@Version("1.5.0")
 package com.adobe.aem.commons.assetshare.util;
 
 import org.osgi.annotation.versioning.Version;

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/image/clientlibs/site/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/image/clientlibs/site/js.txt
@@ -1,0 +1,1 @@
+js/image.js

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/image/clientlibs/site/js/image.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/image/clientlibs/site/js/image.js
@@ -1,28 +1,33 @@
 /*
  * Asset Share Commons
  *
- * Copyright (C) 2017 Adobe
+ * Copyright [2017]  Adobe
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package com.adobe.aem.commons.assetshare.components.details;
+/*global jQuery: false */
 
-public interface Image extends EmptyTextComponent {
-    String getSrc();
+jQuery((function($) {
+    "use strict";
 
-    String getAlt();
+    (function() {
+        $('.cmp-details-image .cmp-details-image__image[data-asset-share-fallback]').error(function() {
+            var element = $(this),
+                fallback = element.data('asset-share-fallback');
 
-    default String getFallback() { return null; }
-}
+            element.removeAttr('data-asset-share-fallback').attr('src', fallback);
+        });
+    }());
+
+}(jQuery)));

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/image/image.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/image/image.html
@@ -23,17 +23,22 @@
     <div class="cmp-wrapper image background">
 
         <!--/* Img element with a max height */-->
-        <img class="ui centered image cmp-image"
+        <img class="ui centered image cmp-image
+                    cmp-image--max-height
+                    cmp-details-image__image
+                    cmp-details-image__image--max-height"
              alt="${image.alt}"
              src="${image.src}"
-             class="cmp-image--max-height"
              style="max-height:${maxHeight @ context = 'styleToken'}px;"
+             data-asset-share-fallback="${image.fallback}"
              data-sly-test.maxHeight="${properties['maxHeight']}"/>
 
         <!--/* Img element without a max height */-->
-        <img class="ui centered image cmp-image"
+        <img class="ui centered image cmp-image
+                    cmp-details-image__image"
              alt="${image.alt}"
              src="${image.src}"
+             data-asset-share-fallback="${image.fallback}"
              data-sly-test="${!maxHeight}"/>
     </div>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/cart.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/cart.html
@@ -18,6 +18,7 @@
 
 <sly    data-sly-use.modelCache="com.adobe.aem.commons.assetshare.util.ModelCache"
         data-sly-test.config="${modelCache['com.adobe.aem.commons.assetshare.configuration.Config']}"
+        data-sly-test.searchConfig="${modelCache['com.adobe.aem.commons.assetshare.components.search.SearchConfig']}"
         data-sly-use.cart="com.adobe.aem.commons.assetshare.components.actions.cart.Cart"></sly>
 
 <style data-sly-test="${!wccmode.disabled}">
@@ -54,7 +55,8 @@
                 data-sly-use.assetDetails="${'com.adobe.aem.commons.assetshare.configuration.AssetDetails' @ request = slingRequest, asset = asset }">
 
                 <td class="image">
-                    <img src="${asset.properties['thumbnail']}" alt="${asset.properties['title']}"/>
+                    <img src="${asset.properties['thumbnail'] || searchConfig.properties['missingImage']  @ context = 'attribute'}"
+                         alt="${asset.properties['title']}"/>
                 </td>
 
                 <td class="header">


### PR DESCRIPTION
Helps resolve issues described in #307/#308 where image previews/thumbnails are broken for unsupported (by the browser)(sometimes image) file formats.
/cc @HitmanInWis 