### PR TITLE
Fixed invalid content reference - cart-remove vs cart-exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- 0335: Fixed a content issue that could result in "Remove From Cart" notification no longer working after saving page properties.
+
 ### Changed
 - 0322: Email Sharing Externalizer extension to allow custom externalizer domain to be used for publish links.
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/clientlibs/site/js/cart-actions.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/clientlibs/site/js/cart-actions.js
@@ -25,7 +25,6 @@ jQuery((function ($, ns, messages, cart, semanticModal, licenseModal) {
         REMOVE_FROM_CART = "remove-from-cart",
 
         MESSAGE_CART_ADD = "cart-add",
-        MESSAGE_CART_EXISTS = "cart-exists",
         MESSAGE_CART_REMOVE = "cart-remove";
 
     /** Add to Cart **/
@@ -39,7 +38,6 @@ jQuery((function ($, ns, messages, cart, semanticModal, licenseModal) {
         e.stopPropagation();
 
         if (cart.contains(assetPath)) {
-            messages.show(MESSAGE_CART_EXISTS);
             return false;
         } else {
             if (license) {

--- a/ui.content/src/main/content/jcr_root/conf/asset-share-commons/settings/wcm/templates/search-template-dark/initial/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/asset-share-commons/settings/wcm/templates/search-template-dark/initial/.content.xml
@@ -34,7 +34,7 @@
                     eventId="cart-add"
                     style="success"
                     text="Asset added to cart"/>
-                <cart-exists
+                <cart-remove
                     jcr:primaryType="nt:unstructured"
                     eventId="cart-remove"
                     style="notice"

--- a/ui.content/src/main/content/jcr_root/content/asset-share-commons/en/dark/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/asset-share-commons/en/dark/.content.xml
@@ -366,7 +366,7 @@
                     eventId="cart-add"
                     style="success"
                     text="Asset added to cart"/>
-                <cart-exists
+                <cart-remove
                     jcr:primaryType="nt:unstructured"
                     eventId="cart-remove"
                     style="notice"

--- a/ui.content/src/main/content/jcr_root/content/asset-share-commons/en/light/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/asset-share-commons/en/light/.content.xml
@@ -366,7 +366,7 @@
                     eventId="cart-add"
                     style="success"
                     text="Asset added to cart"/>
-                <cart-exists
+                <cart-remove
                     jcr:primaryType="nt:unstructured"
                     eventId="cart-remove"
                     style="notice"


### PR DESCRIPTION
Fixed an issue where `cart-remove` node is not created in initial content, creating a situation where opening and saving page properties on the search page causes the "Removed from Cart" notification to no longer fire due to a rogue `cart-exists` node under messages that is not used for anything.