### PR TITLE
Align error title property to "errorTitle"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 0313: Reformatted core/pom.xml
 
 ### Fixed
+- 0344: Fixed a property field mapping in the "Share" component dialog where the property name was `./errorText` instead of `./errorTitle`.
 - 0335: Fixed a content issue that could result in "Remove From Cart" notification no longer working after saving page properties.
 
 - 0326: Removed the sample (non-working) FolderSearchProvider and FolderResult/sImpl from the code base.

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/share/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/share/_cq_dialog/.content.xml
@@ -152,7 +152,7 @@
                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                             emptyText="Error"
                                             fieldLabel="Error Title"
-                                            name="./errorText"
+                                            name="./errorTitle"
                                             required="{Boolean}true"/>
                                     <error-message
                                             jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
In the cq:template file and the share.html of the share modal component, a reference is made to the `errorTitle` property, while the value in the dialog is `./errorText`.
All values are prefilled in the dialog, except for the error title. Making adjustments to this field in the dialog will not impact the value in the jcr since it is storing its value in `./errorText` instead of `./errorTitle`.

Given the standard naming convention (`modalTitle`, `successTitle`,...) I aligned the property name to `errorTitle`. No change to the cq:template or html is required since they already use `errorTitle`.