### PR TITLE
#163 init user menu when profile store is ready or gets updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- 163: User menu disappears when the profile is aleady loaded in previeous requests
+
 ### Changed
 - 0359: Expanded org.apache.sling.xss to [1.2.0,3) to support AEM 6.5 (uses version 2.0.1) and removed unneeded legacy acom.adobe.acs.commons.email;resolution:=optional import.
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/clientlibs/site/js/profile.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/clientlibs/site/js/profile.js
@@ -82,6 +82,7 @@ jQuery((function($, ns, cart) {
         cart.clear();
     });
 
+    profile.eventing.on(ContextHub.Constants.EVENT_STORE_READY, init);
     profile.eventing.on(ContextHub.Constants.EVENT_STORE_UPDATED, init);
 
 }(jQuery,


### PR DESCRIPTION
init user menu (profile.js) not only on profile store 'update' but also on profile store 'ready' event to make sure the user name is displayed on the subsequent page loads