### PR TITLE
Feature/374 - Metadata Schema Properties - Extra Metadata Properties and Blacklist Metadata Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - 0359: Expanded org.apache.sling.xss to [1.2.0,3) to support AEM 6.5 (uses version 2.0.1) and removed unneeded legacy acom.adobe.acs.commons.email;resolution:=optional import.
+- 0374: Added ability to add extra or blacklist Metadata Properties from the Metadata Properties DataSource via OSGi c    lljsfdonfiguration
 
 ## [v1.6.12]
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/MetadataSchemaPropertiesImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/MetadataSchemaPropertiesImpl.java
@@ -81,7 +81,7 @@ public class MetadataSchemaPropertiesImpl implements MetadataProperties {
         }
 
         collectedMetadata = collectExtraMetadataProperties(collectedMetadata);
-        collectedMetadata = removeMetadataProperties(collectedMetadata);
+        collectedMetadata = removeBlacklistedMetadataProperties(collectedMetadata);
 
         return collectedMetadata;
     }
@@ -96,7 +96,7 @@ public class MetadataSchemaPropertiesImpl implements MetadataProperties {
         return collectedMetadata;
     }
 
-    protected final Map<String, List<String>> removeMetadataProperties(final Map<String, List<String>> collectedMetadata) {
+    protected final Map<String, List<String>> removeBlacklistedMetadataProperties(final Map<String, List<String>> collectedMetadata) {
         for (String propertyName : cfg.blacklisted_metadata_properties()) {
 
             String withoutDotSlash = StringUtils.removeStart(propertyName, "./");

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/content/impl/MetadataSchemaPropertiesImplTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/content/impl/MetadataSchemaPropertiesImplTest.java
@@ -1,0 +1,92 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2019 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.adobe.aem.commons.assetshare.content.impl;
+
+import com.adobe.aem.commons.assetshare.content.MetadataProperties;
+import com.google.common.collect.ImmutableMap;
+import io.wcm.testing.mock.aem.junit.AemContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class MetadataSchemaPropertiesImplTest {
+
+    @Rule
+    public final AemContext ctx = new AemContext();
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @Test
+    public void collectExtraMetadataProperties() {
+        ctx.registerInjectActivateService(new MetadataSchemaPropertiesImpl(),
+                ImmutableMap.<String, Object>builder().
+                put("extra.metadata.properties", new String[]{ "jcr:content/foo=My Foo", "jcr:content/metadata/bar=My Bar", "./jcr:content/foo=My Foo 2" }).
+                build());
+
+        MetadataSchemaPropertiesImpl metadataSchemaProperties = (MetadataSchemaPropertiesImpl) ctx.getService(MetadataProperties.class);
+
+        Map<String, List<String>> collectedMetadata = new HashMap<>();
+        collectedMetadata = metadataSchemaProperties.collectExtraMetadataProperties(collectedMetadata);
+
+        assertEquals(2, collectedMetadata.size());
+
+        assertEquals(2, collectedMetadata.get("./jcr:content/foo").size());
+        assertEquals("My Foo", collectedMetadata.get("./jcr:content/foo").get(0));
+        assertEquals("My Foo 2", collectedMetadata.get("./jcr:content/foo").get(1));
+
+        assertEquals(1, collectedMetadata.get("./jcr:content/metadata/bar").size());
+        assertEquals("My Bar", collectedMetadata.get("./jcr:content/metadata/bar").get(0));
+    }
+
+    @Test
+    public void removeMetadataProperties() {
+        ctx.registerInjectActivateService(new MetadataSchemaPropertiesImpl(),
+                ImmutableMap.<String, Object>builder().
+                        put("blacklisted.metadata.properties", new String[]{ "jcr:content/foo" }).
+                        build());
+
+        MetadataSchemaPropertiesImpl metadataSchemaProperties = (MetadataSchemaPropertiesImpl) ctx.getService(MetadataProperties.class);
+
+        Map<String, List<String>> collectedMetadata = new HashMap<>();
+        collectedMetadata.put("jcr:content/foo", Arrays.asList("Blacklisted"));
+        collectedMetadata.put("./jcr:content/foo", Arrays.asList("Blacklisted Too"));
+        collectedMetadata.put("./jcr:content/metadata/bar", Arrays.asList("Not blacklisted"));
+
+        collectedMetadata = metadataSchemaProperties.removeMetadataProperties(collectedMetadata);
+
+        assertEquals(1, collectedMetadata.size());
+        assertEquals(1, collectedMetadata.get("./jcr:content/metadata/bar").size());
+        assertEquals("Not blacklisted", collectedMetadata.get("./jcr:content/metadata/bar").get(0));
+    }
+
+    @Test
+    public void collectMetadataProperty() {
+    }
+
+}

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/content/impl/MetadataSchemaPropertiesImplTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/content/impl/MetadataSchemaPropertiesImplTest.java
@@ -78,7 +78,7 @@ public class MetadataSchemaPropertiesImplTest {
         collectedMetadata.put("./jcr:content/foo", Arrays.asList("Blacklisted Too"));
         collectedMetadata.put("./jcr:content/metadata/bar", Arrays.asList("Not blacklisted"));
 
-        collectedMetadata = metadataSchemaProperties.removeMetadataProperties(collectedMetadata);
+        collectedMetadata = metadataSchemaProperties.removeBlacklistedMetadataProperties(collectedMetadata);
 
         assertEquals(1, collectedMetadata.size());
         assertEquals(1, collectedMetadata.get("./jcr:content/metadata/bar").size());


### PR DESCRIPTION
Added ability to specify, at a global level, via OSGi configuration

* Extra metadata properties - this allows for the addition of properties that may not make sense to show up in the Metadata Schema (even as Read-only)
* Blacklisted metadata properties - this allows for listing properties that should not show up as available Metadata schema properties to select from.


![image](https://user-images.githubusercontent.com/1451868/53040850-7666fe00-3450-11e9-972d-74fb6a2ec6e2.png)
