### PR TITLE
Code error with Shopping Cart - Deleted Assets in Author #352

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - 0359: Expanded org.apache.sling.xss to [1.2.0,3) to support AEM 6.5 (uses version 2.0.1) and removed unneeded legacy acom.adobe.acs.commons.email;resolution:=optional import.
+- 0378: Date range filter includes the end date (evaluated at 12:59:59PM)
 
 ## [v1.6.12]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- 0359: Expanded org.apache.sling.xss to [1.2.0,2) to support AEM 6.5 and removed unneeded legacy acom.adobe.acs.commons.email;resolution:=optional import.
+
 ## [v1.6.12]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Changed
-- 0359: Expanded org.apache.sling.xss to [1.2.0,2) to support AEM 6.5 and removed unneeded legacy acom.adobe.acs.commons.email;resolution:=optional import.
+- 0359: Expanded org.apache.sling.xss to [1.2.0,3) to support AEM 6.5 (uses version 2.0.1) and removed unneeded legacy acom.adobe.acs.commons.email;resolution:=optional import.
 
 ## [v1.6.12]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- 163: User menu disappears when the profile is aleady loaded in previeous requests
+
 ### Changed
 - 0359: Expanded org.apache.sling.xss to [1.2.0,3) to support AEM 6.5 (uses version 2.0.1) and removed unneeded legacy acom.adobe.acs.commons.email;resolution:=optional import.
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -172,7 +172,7 @@
                     <exportScr>true</exportScr>
                     <instructions>
                         <Import-Package>
-                            org.apache.sling.xss;version="[1.2.0,2)",
+                            org.apache.sling.xss;version="[1.2,3)",
                             *
                         </Import-Package>
                         <_plugin>org.apache.sling.bnd.models.ModelsScannerPlugin</_plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -172,7 +172,7 @@
                     <exportScr>true</exportScr>
                     <instructions>
                         <Import-Package>
-                            com.adobe.acs.commons.email;resolution:=optional,
+                            org.apache.sling.xss;version="[1.2.0,2)",
                             *
                         </Import-Package>
                         <_plugin>org.apache.sling.bnd.models.ModelsScannerPlugin</_plugin>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/plug-ins.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/plug-ins.js
@@ -72,7 +72,7 @@ $(function () {
                     date: dateFormatter
                 },
                 onChange: function (date, text, mode) {
-                    $(rangeEnd).find('input[type="text"]').val(text).trigger("change");
+                    $(rangeEnd).find('input[type="text"]').val(text+'T23:59:59').trigger("change");
                 }
             });
         });

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/clientlibs/site/js/profile.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/clientlibs/site/js/profile.js
@@ -82,6 +82,7 @@ jQuery((function($, ns, cart) {
         cart.clear();
     });
 
+    profile.eventing.on(ContextHub.Constants.EVENT_STORE_READY, init);
     profile.eventing.on(ContextHub.Constants.EVENT_STORE_UPDATED, init);
 
 }(jQuery,


### PR DESCRIPTION
Description:
Cart functionality is not updating the value if asset is deleted from dam author.
Environment: Replicable in all instance

* AEM Version: 6.3
* Asset Share Commons Version: 1.6.10
* Author, Publish or both? Author

**To Reproduce**
Steps to reproduce the behavior:

1. Login to AEM Author Instance.
2. Install Asset-share commons in Author Instance.
3. By default Add to cart will be empty as shown below.
4. Add 2 images to the cart as shown below.
5. Delete one of the assets from the dam author as shown below.
6. Refresh the Home page where we have added the asset to cart.
7. The asset is deleted and even though add to cart shows the same number.
8. Click on the add to cart, it will show only one asset and the count of the asset shows as 2.
9. Add one more asset to the cart, it shows the count as 3 shown below.
10. Open the cart and check 2 assets will be present, but it shows the count as 3.

**Expected behavior**

1. Login to Author Instance.
2. Add 2 assets to cart.
3. Add to cart has to show as 2.
4. Remove one asset from the dam author.
5. Refresh the home page.
6. Check the Add to cart has to show as 1.
   **Screenshots**
   Attaching steps to reproduce the issue
 @godanny86  As you mentioned i am raising a pull request for this issie.