### PR TITLE
Feature/265 - Freeform-text component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ content/src/main/content/jcr_root/apps/.content.xml
 content/src/main/content/jcr_root/etc/.content.xml
 content/src/main/content/jcr_root/etc/designs/.content.xml
 content/src/main/content/jcr_root/etc/clientlibs/.content.xml
+
+ui.tests/node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 0313: Reformatted core/pom.xml
 - 0322: Email Sharing Externalizer extension to allow custom externalizer domain to be used for publish links.
 - 0327: Updated SearchPredicateDataSource and AssetDetailsResolver to GREEDY'ily acquire @References to allow 3rd party service impls to register properly.
+- 0265: Added custom-delimiter support to PropertyValues predicate evalutor.
 
 ### Added
 - 0303: Added ability to hide the Apply Filter Toggle control completely (useful for when auto-search on change is enabled everywhere)
+- 0265: Added Freeform-text search component
 
 ## [v1.6.10]
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/FreeformTextPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/FreeformTextPredicate.java
@@ -1,0 +1,65 @@
+package com.adobe.aem.commons.assetshare.components.predicates;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+import java.util.List;
+
+@ProviderType
+public interface FreeformTextPredicate extends Predicate {
+    /**
+     * @return the predicate title.
+     */
+    String getTitle();
+
+    /**
+     * The output of this is coupled with the ASC implementation of PropertyValuesPredicateEvaluator.
+     *
+     * @return a list of delimiters (or delimiter codes) used to split the entry.
+     */
+    List<String> getDelimiters();
+
+    /**
+     * @return the fields placeholder text
+     */
+    String getPlaceholder();
+
+    /**
+     * @return the number of rows the input text field should be.
+     */
+    int getRows();
+
+    /**
+     * @return the relative property path used for this predicate.
+     */
+    String getProperty();
+
+    /**
+     * @return the querybuilder predication operation (equals, not equals, exists)
+     */
+    String getOperation();
+
+    /**
+     * @return true of an operation is set.
+     */
+    boolean hasOperation();
+
+    /**
+     * @return the min input length allowed for this field, or null if no limit exists.
+     */
+    Integer getInputValidationMinLength();
+
+    /**
+     * @return the max input length allowed for this field, or null if no limit exists.
+     */
+    Integer getInputValidationMaxLength();
+
+    /**
+     * @return the pattern to validate input, or null if no pattern is to be used.
+     */
+    String getInputValidationPattern();
+
+    /**
+     * @return the message to display to the user if the provided input is invalid.
+     */
+    String getInputValidationMessage();
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PropertyPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PropertyPredicate.java
@@ -29,6 +29,11 @@ import java.util.List;
 public interface PropertyPredicate extends Predicate {
 
     /**
+     * @return true of an operation is set.
+     */
+    default boolean hasOperation() { return false; }
+
+    /**
      * @return the querybuilder predication operation (equals, not equals, exists)
      */
     String getOperation();

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/FreeformTextPredicatePredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/FreeformTextPredicatePredicateImpl.java
@@ -1,0 +1,216 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2018 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.adobe.aem.commons.assetshare.components.predicates.impl;
+
+import com.adobe.aem.commons.assetshare.components.predicates.AbstractPredicate;
+import com.adobe.aem.commons.assetshare.components.predicates.FreeformTextPredicate;
+import com.adobe.aem.commons.assetshare.search.impl.predicateevaluators.PropertyValuesPredicateEvaluator;
+import com.adobe.aem.commons.assetshare.util.PredicateUtil;
+import org.apache.commons.lang.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.models.annotations.Default;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.Required;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Named;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static java.util.Collections.EMPTY_LIST;
+
+@Model(
+        adaptables = {SlingHttpServletRequest.class},
+        adapters = {FreeformTextPredicate.class},
+        resourceType = {FreeformTextPredicatePredicateImpl.RESOURCE_TYPE},
+        defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
+)
+public class FreeformTextPredicatePredicateImpl extends AbstractPredicate implements FreeformTextPredicate {
+    protected static final String RESOURCE_TYPE = "asset-share-commons/components/search/freeform-text";
+    private static final String CUSTOM_DELIMITER = "__CUSTOM_DELIMITER";
+
+    private static final String PN_DELIMITER_VALUE = "value";
+    private static final String PN_DELIMITER_CUSTOM_VALUE = "customValue";
+    private static final String NN_DELIMITERS = "delimiters";
+
+    private static final String OP_STARTS_WITH = "startsWith";
+
+    @Self
+    @Required
+    private SlingHttpServletRequest request;
+
+    @ValueMapValue
+    @Named("jcr:title")
+    private String title;
+
+    @ValueMapValue
+    private String property;
+
+    @ValueMapValue
+    private String operation;
+
+    @ValueMapValue
+    private String placeholder;
+
+    @ValueMapValue
+    private Integer inputValidationMinLength;
+
+    @ValueMapValue
+    private Integer inputValidationMaxLength;
+
+    @ValueMapValue
+    private String inputValidationPattern;
+
+    @ValueMapValue
+    private String inputValidationMessage;
+
+    @ValueMapValue
+    @Default(intValues = 1)
+    private int rows;
+
+    @ValueMapValue(name = PropertyPredicateImpl.PN_TYPE)
+    private String typeString;
+    
+    protected List<String> delimiters = null;
+    protected String valueFromRequest = null;
+    protected ValueMap valuesFromRequest = null;
+
+    @PostConstruct
+    protected void init() {
+        super.initGroup(request);
+    }
+
+    @Override
+    public String getTitle() {
+        return this.title;
+    }
+
+    @Override
+    public String getPlaceholder() {
+        return this.placeholder;
+    }
+
+    @Override
+    public String getName() {
+        return PropertyValuesPredicateEvaluator.PREDICATE_NAME;
+    }
+
+    @Override
+    public int getRows() {
+        return this.rows;
+    }
+
+    @Override
+    public String getOperation() {
+        return operation;
+    }
+
+    @Override
+    public boolean hasOperation() {
+        return StringUtils.isNotBlank(getOperation());
+    }
+
+    @Override
+    public String getProperty() {
+        return property;
+    }
+
+    @Override
+    public Integer getInputValidationMinLength() {
+        if (StringUtils.equals(OP_STARTS_WITH, getOperation()) &&
+                (inputValidationMinLength == null || inputValidationMinLength < 3)) {
+            // Magic minimum number for like operations
+            return 3;
+        } else {
+            return inputValidationMinLength;
+        }
+    }
+
+    @Override
+    public Integer getInputValidationMaxLength() {
+        return inputValidationMaxLength;
+    }
+
+    @Override
+    public String getInputValidationPattern() {
+        return StringUtils.stripToNull(inputValidationPattern);
+    }
+
+    @Override
+    public String getInputValidationMessage() {
+        return StringUtils.stripToNull(inputValidationMessage);
+    }
+
+    @Override
+    public List<String> getDelimiters() {
+
+        if (delimiters == null) {
+            Resource delimitersResource = request.getResource().getChild(NN_DELIMITERS);
+
+            if (delimitersResource == null) {
+                return EMPTY_LIST;
+            }
+
+            delimiters = StreamSupport.stream(delimitersResource.getChildren().spliterator(), false).map(option -> {
+                final ValueMap properties = option.getValueMap();
+                final String value = properties.get(PN_DELIMITER_VALUE, String.class);
+                final String customValue = properties.get(PN_DELIMITER_CUSTOM_VALUE, String.class);
+
+                if (CUSTOM_DELIMITER.equals(value)) {
+                    return customValue;
+                } else {
+                    return value;
+                }
+
+            }).collect(Collectors.toList());
+        }
+
+        return delimiters;
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public String getInitialValue() {
+        if (valueFromRequest == null) {
+            valueFromRequest = PredicateUtil.getInitialValue(request, this, PropertyValuesPredicateEvaluator.VALUES);
+        }
+
+        return valueFromRequest;
+    }
+
+    @Override
+    public ValueMap getInitialValues() {
+        if (valuesFromRequest == null) {
+            valuesFromRequest = PredicateUtil.getInitialValues(request, this, PropertyValuesPredicateEvaluator.VALUES);
+        }
+
+        return valuesFromRequest;
+    }
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
@@ -126,6 +126,7 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
         return typeString;
     }
 
+    @Override
     public String getProperty() {
         return property;
     }
@@ -135,10 +136,12 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
         return PropertyValuesPredicateEvaluator.VALUES;
     }
 
+    @Override
     public boolean hasOperation() {
         return StringUtils.isNotBlank(getOperation());
     }
 
+    @Override
     public String getOperation() {
         return operation;
     }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/options/CustomOptionItem.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/options/CustomOptionItem.java
@@ -1,0 +1,62 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2018 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.adobe.aem.commons.assetshare.components.predicates.impl.options;
+
+import com.adobe.cq.wcm.core.components.models.form.OptionItem;
+import org.apache.commons.lang3.StringUtils;
+
+public class CustomOptionItem implements OptionItem {
+    private final boolean selected;
+    private final String text;
+    private String value;
+    private String customValue;
+
+    public CustomOptionItem(final String value, final String customValue) {
+        this(null, value, customValue, false);
+    }
+
+    public CustomOptionItem(final String text, final String value, final String customValue, final boolean selected) {
+        this.text = text;
+        this.selected = selected;
+        this.value = value;
+        this.customValue = value;
+    }
+
+    @Override
+    public boolean isSelected() {
+        return selected;
+    }
+
+    @Override
+    public boolean isDisabled() {
+        return false;
+    }
+
+    @Override
+    public String getValue() {
+        return StringUtils.defaultIfEmpty(customValue, value);
+    }
+
+    @Override
+    public String getText() {
+        return text;
+    }
+
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("3.0.0")
+@Version("3.1.0")
 package com.adobe.aem.commons.assetshare.components.predicates;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/FastProperties.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/FastProperties.java
@@ -19,6 +19,7 @@
 
 package com.adobe.aem.commons.assetshare.search;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.osgi.annotation.versioning.ProviderType;
 
 import java.util.Collection;
@@ -32,7 +33,13 @@ import java.util.List;
 public interface FastProperties {
     String SLOW = "\uD83D\uDC22"; // Turtle in Unicode
     String FAST = "\u26A1"; // Lightning bolt in Unicode
-    String DELTA = "\uD83D\uDDF2";
+    String DELTA = FAST; // Fast index properties that are not in Metadata schema
+
+    /**
+     * If it does, this propertyName (ie. jcr:content/metadata/dc:title) is added to the return list.
+     * @return a list of property paths who have index rules configured (with not flag restrictions).
+     */
+    List<String> getFastProperties();
 
     /**
      * Checks if the /oak:index/damAssetLucene index (or whatever may be overridden via FastPropertiesImpl OSGi Config) has a indexRule property config with the a property named indexConfigFlagPropertyName set to true.
@@ -43,6 +50,16 @@ public interface FastProperties {
     List<String> getFastProperties(String indexConfigFlagPropertyName);
 
     /**
+     * Checks if the /oak:index/damAssetLucene index (or whatever may be overridden via FastPropertiesImpl OSGi Config) has a indexRule property config with propertys named in indexConfigFlagPropertyName set to true (all must be set to true).
+     * If it does, this propertyName (ie. jcr:content/metadata/dc:title) is added to the return list.
+     * @param indexConfigFlagPropertyNames the oak index property names that acts as the true/false flag to check. All properties must evaluate to true.
+     * @return a list of property paths as who are configured with all @{param indexConfigFlagPropertyNames} set to `true`
+     */
+    default List<String> getFastProperties(List<String> indexConfigFlagPropertyNames) { return Collections.emptyList(); }
+
+    /**
+     * This is usually used to computed the list of index properties that are not in any Metadata schemas.
+     *
      * @param fastProperties a list relative property paths that are considered to be fast.
      * @param otherProperties a list of other relative property paths.
      * @return the delta between the fastProperties and the otherProperties.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/FastPropertiesImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/FastPropertiesImpl.java
@@ -42,20 +42,33 @@ public class FastPropertiesImpl implements FastProperties {
 
     private static final String SERVICE_NAME = "oak-index-definition-reader";
 
-    private static final String DEFAULT_INDEX_DEFINITION_RULES_PATH = "/oak:index/damAssetLucene/indexRules/dam:Asset/properties";
-    private String[] indexDefinitionRulesPaths = new String[]{DEFAULT_INDEX_DEFINITION_RULES_PATH};
+    protected static final String DEFAULT_INDEX_DEFINITION_RULES_PATH = "/oak:index/damAssetLucene/indexRules/dam:Asset/properties";
+    protected static final Map<String, Object> AUTH_INFO = Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, SERVICE_NAME);
+
+    protected String[] indexDefinitionRulesPaths = new String[]{DEFAULT_INDEX_DEFINITION_RULES_PATH};
 
     @Reference
     private ResourceResolverFactory resourceResolverFactory;
 
+
+    @Override
+    public final List<String> getFastProperties() {
+        return getFastProperties(Collections.EMPTY_LIST);
+    }
+
+    @Override
     public final List<String> getFastProperties(final String indexConfigFlagPropertyName) {
-        final List<String> fastProperties = new ArrayList<>();
+        return getFastProperties(Arrays.asList(indexConfigFlagPropertyName));
+    }
+
+    @Override
+    public final List<String> getFastProperties(final List<String> indexConfigFlagPropertyNames) {
+        final Set<String> fastProperties = new TreeSet<>();
 
         ResourceResolver resourceResolver = null;
 
         try {
-            final Map<String, Object> authInfo = Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, (Object) SERVICE_NAME);
-            resourceResolver = resourceResolverFactory.getServiceResourceResolver(authInfo);
+            resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
 
             for (final String indexDefinitionRulesPath : indexDefinitionRulesPaths) {
                 final Resource damAssetIndexRulesResource = resourceResolver.getResource(indexDefinitionRulesPath);
@@ -70,11 +83,13 @@ public class FastPropertiesImpl implements FastProperties {
                     final Resource indexRule = indexRules.next();
                     final ValueMap properties = indexRule.getValueMap();
 
-                    if (properties.get(indexConfigFlagPropertyName, false)) {
-                        final String relPath = properties.get(PN_NAME, String.class);
-                        if (StringUtils.isNotBlank(relPath)) {
-                            fastProperties.add(relPath);
-                        }
+                    final String relPath = StringUtils.stripToNull(properties.get(PN_NAME, String.class));
+
+                    if (relPath != null
+                            && (indexConfigFlagPropertyNames == null
+                            || indexConfigFlagPropertyNames.isEmpty()
+                            || indexConfigFlagPropertyNames.stream().allMatch(propertyName -> properties.get(propertyName, false)))) {
+                        fastProperties.add(relPath);
                     }
                 }
             }
@@ -86,7 +101,7 @@ public class FastPropertiesImpl implements FastProperties {
             }
         }
 
-        return fastProperties;
+        return new ArrayList<>(fastProperties);
     }
 
     public List<String> getDeltaProperties(final Collection<String> fastProperties, final Collection<String> otherProperties) {
@@ -120,7 +135,6 @@ public class FastPropertiesImpl implements FastProperties {
     public String getSlowLabel(final String label) {
         return SLOW + "  " + label;
     }
-
 
     @Activate
     protected void activate(Cfg cfg) {

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/datasources/FilterablePropertiesDataSource.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/datasources/FilterablePropertiesDataSource.java
@@ -22,6 +22,7 @@ package com.adobe.aem.commons.assetshare.search.impl.datasources;
 import com.adobe.aem.commons.assetshare.content.MetadataProperties;
 import com.adobe.aem.commons.assetshare.search.FastProperties;
 import com.adobe.aem.commons.assetshare.util.DataSourceBuilder;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -47,6 +48,7 @@ import java.util.*;
 public class FilterablePropertiesDataSource extends SlingSafeMethodsServlet {
     private static final String PN_METADATA_FIELD_TYPES = "metadataFieldTypes";
     private static final String PN_PROPERTY_INDEX = "propertyIndex";
+    private static final String PN_FILTER_PROPERTIES = "indexRuleCapabilities";
 
     @Reference
     private DataSourceBuilder dataSourceBuilder;
@@ -58,14 +60,14 @@ public class FilterablePropertiesDataSource extends SlingSafeMethodsServlet {
     private MetadataProperties metadataProperties;
 
     @Override
-    protected final void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws
-            ServletException, IOException {
+    protected final void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) {
         final Map<String, Object> data = new TreeMap<>();
         final ValueMap properties = request.getResource().getValueMap();
-        final List<String> metadataFieldTypes = Arrays.asList(properties.get(PN_METADATA_FIELD_TYPES, new String[]{}));
+        final List<String> metadataFieldTypes = Arrays.asList(properties.get(PN_METADATA_FIELD_TYPES, ArrayUtils.EMPTY_STRING_ARRAY));
+        final List<String> indexRuleCapabilityProperties = Arrays.asList(properties.get(PN_FILTER_PROPERTIES, new String[] { PN_PROPERTY_INDEX} ));
 
         final Map<String, List<String>> collectedMetadata = metadataProperties.getMetadataProperties(request, metadataFieldTypes);
-        final List<String> fastProperties = fastPropertiesService.getFastProperties(PN_PROPERTY_INDEX);
+        final List<String> fastProperties = fastPropertiesService.getFastProperties(indexRuleCapabilityProperties);
 
         for (final Map.Entry<String, List<String>> entry : collectedMetadata.entrySet()) {
             final String label = StringUtils.join(entry.getValue(), " / ") + " (" + StringUtils.removeStart(entry.getKey(), "./") + ")";
@@ -78,17 +80,17 @@ public class FilterablePropertiesDataSource extends SlingSafeMethodsServlet {
             }
         }
 
-
-        if(metadataFieldTypes.isEmpty()) {
+        if (metadataFieldTypes.isEmpty()) {
             addDeltaFastProperties(data, fastProperties);
         }
+
         dataSourceBuilder.build(request, data);
     }
 
     private void addDeltaFastProperties(Map<String, Object> data, List<String> fastProperties) {
-        final List<String> deltaFastProperties = fastPropertiesService
-            .getDeltaProperties(fastProperties,
-                (Collection<String>) (Collection<?>) data.values());
+        final List<String> deltaFastProperties =
+                fastPropertiesService.getDeltaProperties(fastProperties,
+                        (Collection<String>) (Collection<?>) data.values());
 
         for (String deltaFastProperty : deltaFastProperties) {
             data.put(FastProperties.DELTA + " " + deltaFastProperty, deltaFastProperty);

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PredicateEvaluatorUtil.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PredicateEvaluatorUtil.java
@@ -1,0 +1,35 @@
+package com.adobe.aem.commons.assetshare.search.impl.predicateevaluators;
+
+import com.day.cq.search.Predicate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class PredicateEvaluatorUtil {
+
+    public static List<String> getValues(final Predicate predicate, final String parameterName) {
+        return getValues(predicate, parameterName, false);
+    }
+
+    public static List<String> getValues(final Predicate predicate, final String parameterName, final boolean nullify) {
+        final List<String> values = new ArrayList<>();
+
+        predicate.getParameters().entrySet().stream().forEach(entry -> {
+            final Pattern pattern = Pattern.compile("^(\\d+_)?" + parameterName + "$");
+            final Matcher matcher = pattern.matcher(entry.getKey());
+
+            if (matcher.matches()) {
+                values.add(entry.getValue());
+
+                if (nullify) {
+                    predicate.set(entry.getKey(), null);
+                }
+            }
+        });
+
+        return values;
+    }
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PropertyValuesPredicateEvaluator.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PropertyValuesPredicateEvaluator.java
@@ -1,7 +1,7 @@
 /*
  * Asset Share Commons
  *
- * Copyright (C) 2017 Adobe
+ * Copyright (C) 2018 Adobe
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,15 +21,28 @@ package com.adobe.aem.commons.assetshare.search.impl.predicateevaluators;
 
 import com.day.cq.search.Predicate;
 import com.day.cq.search.eval.EvaluationContext;
+import com.day.cq.search.eval.FulltextPredicateEvaluator;
+import com.day.cq.search.eval.JcrPropertyPredicateEvaluator;
 import com.day.cq.search.eval.PredicateEvaluator;
 import com.day.cq.search.facets.FacetExtractor;
-import org.apache.commons.lang.StringUtils;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jcr.query.Row;
 import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
 
 /**
  * The QueryBuilder predicate for this Sample would be structured like so...
@@ -45,74 +58,244 @@ import java.util.*;
  * `delimiter` is the delimiter which is used to split the values string
  */
 @Component(factory = "com.day.cq.search.eval.PredicateEvaluator/" + PropertyValuesPredicateEvaluator.PREDICATE_NAME)
+@Designate(ocd = PropertyValuesPredicateEvaluator.Cfg.class)
 public class PropertyValuesPredicateEvaluator implements PredicateEvaluator {
+    private static final Logger log = LoggerFactory.getLogger(PropertyValuesPredicateEvaluator.class);
+
+    private PredicateEvaluator propertyEvaluator = new JcrPropertyPredicateEvaluator();
+    private PredicateEvaluator fulltextEvaluator = new FulltextPredicateEvaluator();
+
+    private static final String OP_STARTS_WITH = "startsWith";
+    private static final String OP_CONTAINS = "contains";
+
+    protected static final String PREDICATE_BUILT_KEY = "__asset-share-commons--predicate-built";
+    protected static final String PREDICATE_BUILT_VALUE = "true";
+    protected static final String DELIMITER_CODE_NONE = "__NONE";
+    protected static final String DELIMITER_CODE_WHITESPACE = "__WS";
+
+    private Map<String, String> delimiterMapping = new HashMap<>();
+
+    protected Cfg cfg;
 
     public static final String PREDICATE_NAME = "propertyvalues";
     public static final String VALUES = "values";
     private static final String DELIMITER = "delimiter";
-    private static final String DEFAULT_DELIMITER = ",";
 
-    private PredicateEvaluator propertyEvaluator = new com.day.cq.search.eval.JcrPropertyPredicateEvaluator();
-
-    private Predicate buildPredicate(Predicate predicate) {
-        final String delimiter = StringUtils.defaultIfEmpty(predicate.get(DELIMITER), DEFAULT_DELIMITER);
-        final List<String> properties = new ArrayList<>();
-
-        for (final Map.Entry<String, String> entry : predicate.getParameters().entrySet()) {
-            if (entry.getValue() != null &&
-                    entry.getKey() != null &&
-                    (VALUES.equals(entry.getKey()) || StringUtils.endsWith(entry.getKey(), "_" + VALUES))) {
-                properties.addAll(Arrays.asList(StringUtils.split(entry.getValue(), delimiter)));
-                predicate.set(entry.getKey(), null);
-            }
+    protected Predicate buildPredicate(Predicate predicate) {
+        if (PREDICATE_BUILT_VALUE.equals(predicate.get(PREDICATE_BUILT_KEY))) {
+            return predicate;
         }
 
-        predicate.set(DELIMITER, null);
+        final List<String> delimiters = getDelimiters(predicate);
+        final List<String> values = new ArrayList<>();
 
-        for (int i = 0; i < properties.size(); i++) {
-            predicate.set(i + "_value", properties.get(i));
+        PredicateEvaluatorUtil.getValues(predicate, VALUES, true)
+                .forEach(value -> values.addAll(getValues(value, delimiters)));
+
+        if (isFulltextOperation(predicate)) {
+            predicate = buildFulltextPredicate(predicate, values, predicate.get(JcrPropertyPredicateEvaluator.PROPERTY));
+        } else {
+            predicate = buildPropertyPredicate(predicate, values);
         }
+
+        predicate.set(PREDICATE_BUILT_KEY, PREDICATE_BUILT_VALUE);
 
         return predicate;
     }
 
+
+    private Predicate buildPropertyPredicate(Predicate predicate, List<String> values) {
+        final Predicate propertyPredicate = new Predicate(predicate.getName(), JcrPropertyPredicateEvaluator.PROPERTY);
+
+        for (int i = 0; i < values.size(); i++) {
+            propertyPredicate.set(i + "_"  + JcrPropertyPredicateEvaluator.VALUE, values.get(i));
+        }
+
+        predicate.getParameters().entrySet().stream()
+                .filter(entry -> !entry.getKey().matches("^(\\d+_)?values$"))
+                .filter(entry -> !entry.getKey().matches("^(\\d+_)?delimiter$"))
+                .forEach(entry -> propertyPredicate.set(entry.getKey(), entry.getValue()));
+
+        return propertyPredicate;
+    }
+
+    private Predicate buildFulltextPredicate(Predicate predicate, List<String> values, String property) {
+        final String operation = predicate.get(JcrPropertyPredicateEvaluator.OPERATION);
+
+        final String queryParam = values.stream()
+                .map(StringUtils::trimToNull)
+                .filter(Objects::nonNull)
+                .filter(value -> value.length() >= 3)
+                .map(value -> buildFulltextValue(operation, value))
+                .collect(Collectors.joining(" OR "));
+
+        final Predicate fulltextPredicate = new Predicate(predicate.getName(), FulltextPredicateEvaluator.FULLTEXT);
+
+        fulltextPredicate.set(FulltextPredicateEvaluator.FULLTEXT, queryParam);
+
+        property = StringUtils.removeStart(property, "./");
+        final String[] propertySegments = StringUtils.split(property, "/");
+        final int lastIndex = propertySegments.length - 1;
+        propertySegments[lastIndex] = "@" + propertySegments[lastIndex];
+        property = StringUtils.join(propertySegments, "/");
+
+        fulltextPredicate.set(FulltextPredicateEvaluator.REL_PATH, property);
+
+        return fulltextPredicate;
+    }
+
+    private String buildFulltextValue(String operation, String value) {
+        value = StringUtils.strip(value, "*") + "*";
+
+        if (!OP_STARTS_WITH.equals(operation)) {
+            value = "*" + value;
+        }
+
+        return value;
+    }
+
+    private boolean isFulltextOperation(Predicate predicate) {
+        return ArrayUtils.contains(new String[] {OP_STARTS_WITH, OP_CONTAINS},
+                predicate.get(JcrPropertyPredicateEvaluator.OPERATION));
+    }
+
+    protected PredicateEvaluator getPredicateEvaluator(Predicate predicate) {
+        if(isFulltextOperation(predicate)) {
+            return fulltextEvaluator;
+        } else {
+            return propertyEvaluator;
+        }
+    }
+
     @Override
     public String getXPathExpression(Predicate predicate, EvaluationContext evaluationContext) {
-        return propertyEvaluator.getXPathExpression(buildPredicate(predicate), evaluationContext);
+        return getPredicateEvaluator(predicate).getXPathExpression(buildPredicate(predicate), evaluationContext);
     }
 
     @Override
     public boolean includes(final Predicate predicate, final Row row, final EvaluationContext evaluationContext) {
-        return propertyEvaluator.includes(buildPredicate(predicate), row, evaluationContext);
+        return getPredicateEvaluator(predicate).includes(buildPredicate(predicate), row, evaluationContext);
     }
 
     @Override
     public boolean canXpath(final Predicate predicate, final EvaluationContext evaluationContext) {
-        return propertyEvaluator.canXpath(buildPredicate(predicate), evaluationContext);
+        return getPredicateEvaluator(predicate).canXpath(buildPredicate(predicate), evaluationContext);
     }
 
     @Override
     public boolean canFilter(final Predicate predicate, final EvaluationContext evaluationContext) {
-        return propertyEvaluator.canFilter(buildPredicate(predicate), evaluationContext);
+        return getPredicateEvaluator(predicate).canFilter(buildPredicate(predicate), evaluationContext);
     }
 
     @Override
     public boolean isFiltering(final Predicate predicate, final EvaluationContext evaluationContext) {
-        return propertyEvaluator.isFiltering(buildPredicate(predicate), evaluationContext);
+        return getPredicateEvaluator(predicate).isFiltering(buildPredicate(predicate), evaluationContext);
     }
 
     @Override
     public String[] getOrderByProperties(Predicate predicate, EvaluationContext evaluationContext) {
-        return propertyEvaluator.getOrderByProperties(buildPredicate(predicate), evaluationContext);
+        return getPredicateEvaluator(predicate).getOrderByProperties(buildPredicate(predicate), evaluationContext);
     }
 
     @Override
     public Comparator<Row> getOrderByComparator(Predicate predicate, EvaluationContext evaluationContext) {
-        return getOrderByComparator(buildPredicate(predicate), evaluationContext);
+        return getPredicateEvaluator(predicate).getOrderByComparator(buildPredicate(predicate), evaluationContext);
     }
 
     @Override
     public FacetExtractor getFacetExtractor(Predicate predicate, EvaluationContext evaluationContext) {
-        return propertyEvaluator.getFacetExtractor(buildPredicate(predicate), evaluationContext);
+        return getPredicateEvaluator(predicate).getFacetExtractor(buildPredicate(predicate), evaluationContext);
+    }
+
+    protected List<String> getValues(final String data, final List<String> delimiters) {
+        if (delimiters.size() == 0) {
+            return ImmutableList.<String>builder().add(data).build();
+        }
+
+        final String regex = delimiters.stream()
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.joining("|"));
+
+        final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
+
+        if (data == null) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.stream(pattern.split(data))
+                .map(StringUtils::trimToNull)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    protected List<String> getDelimiters(final Predicate predicate) {
+        final List<String> delimiterValues = PredicateEvaluatorUtil.getValues(predicate, DELIMITER, true);
+
+        if (delimiterValues.stream().anyMatch(DELIMITER_CODE_NONE::equals)) {
+            // "None" is the in the list so do not process ANY of the delimiters
+            return emptyList();
+        }
+
+        final List<String> delimiters = delimiterValues.stream()
+                .map(this::resolveDelimiter)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        if (delimiters.isEmpty() && cfg.delimiters_default() != null) {
+            // If the delimiters is completely empty, then use the default list
+            return Stream.of(cfg.delimiters_default()).map(Pattern::quote).collect(Collectors.toList());
+        } else {
+            // Else return the passed in delimiters
+            return delimiters;
+        }
+    }
+
+    private String resolveDelimiter(String delimiter) {
+        final String resolvedDelimiter = delimiterMapping.get(delimiter);
+
+        if (DELIMITER_CODE_NONE.equals(delimiter)) {
+            return null;
+        } else if (DELIMITER_CODE_WHITESPACE.equals(delimiter)) {
+            return "\\s";
+        } else if (resolvedDelimiter != null) {
+            return Pattern.quote(resolvedDelimiter);
+        } else if (delimiter != null) {
+            return Pattern.quote(delimiter);
+        } else {
+            return null;
+        }
+    }
+
+    @Activate
+    protected void activate(final Cfg cfg) {
+        this.cfg = cfg;
+
+        delimiterMapping = new HashMap<>();
+
+        if (cfg.delimiters_mapping() != null) {
+            Arrays.stream(cfg.delimiters_mapping()).forEach(mapping -> {
+                final String key = StringUtils.substringBefore(mapping, "=");
+                final String value = StringUtils.substringAfter(mapping, "=");
+
+                if (key != null) {
+                    delimiterMapping.put(key, value);
+                }
+            });
+        }
+    }
+
+    @ObjectClassDefinition(name = "Asset Share Commons - Properties Values Predicate Evaluator")
+    public @interface Cfg {
+        @AttributeDefinition(
+                name = "Default delimiter",
+                description = "The default delimiters to use when none no #_delimiter= is specified. Defaults to ','."
+        )
+        String[] delimiters_default() default { "," };
+
+        @AttributeDefinition(
+                name = "Delimiters mapping",
+                description = "Defines custom mappings for delimiter codes to actual delimiters."
+        )
+        String[] delimiters_mapping() default {};
     }
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("2.1.0")
+@Version("2.2.0")
 package com.adobe.aem.commons.assetshare.search;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/FastPropertiesImplTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/FastPropertiesImplTest.java
@@ -1,0 +1,153 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2018 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.adobe.aem.commons.assetshare.search.impl;
+
+import com.adobe.aem.commons.assetshare.search.FastProperties;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.wcm.testing.mock.aem.junit.AemContext;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Reference;
+
+import java.util.Collection;
+import java.util.List;
+
+import static com.adobe.aem.commons.assetshare.search.impl.FastPropertiesImpl.AUTH_INFO;
+import static com.adobe.aem.commons.assetshare.search.impl.FastPropertiesImpl.DEFAULT_INDEX_DEFINITION_RULES_PATH;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.doReturn;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FastPropertiesImplTest {
+
+    @Rule
+    public AemContext ctx = new AemContext();
+
+    @Before
+    public void setUp() throws Exception {
+        ctx.load().json("/com/adobe/aem/commons/assetshare/search/impl/FastPropertiesImplTest.json", DEFAULT_INDEX_DEFINITION_RULES_PATH);
+
+        ctx.registerInjectActivateService(new FastPropertiesImpl());
+    }
+
+    @Test
+    public void getFastProperties_WithNoParams() {
+        final FastProperties fastProperties = ctx.getService(FastProperties.class);
+
+        final List<String> expected = ImmutableList.of(
+                "jcr:content/analyzedIndexRule",
+                "jcr:content/propertyAndAnalyzedIndexRule",
+                "jcr:content/propertyIndexRule",
+                "jcr:content/vanilla");
+
+        final List<String> actual = fastProperties.getFastProperties();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getFastProperties_WithPropertyIndexParam() {
+        final FastProperties fastProperties = ctx.getService(FastProperties.class);
+
+        final List<String> expected = ImmutableList.of(
+                "jcr:content/propertyAndAnalyzedIndexRule",
+                "jcr:content/propertyIndexRule");
+
+        final List<String> actual = fastProperties.getFastProperties("propertyIndex");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getFastProperties_WithAnalyzedIndexParam() {
+        final FastProperties fastProperties = ctx.getService(FastProperties.class);
+
+        final List<String> expected = ImmutableList.of(
+                "jcr:content/analyzedIndexRule",
+                "jcr:content/propertyAndAnalyzedIndexRule");
+
+        final List<String> actual = fastProperties.getFastProperties("analyzed");
+
+        assertEquals(expected, actual);
+    }
+
+
+    @Test
+    public void getFastProperties_WithAnalyzedAndPropertyIndexParams() {
+        final FastProperties fastProperties = ctx.getService(FastProperties.class);
+
+        final List<String> expected = ImmutableList.of(
+                "jcr:content/propertyAndAnalyzedIndexRule");
+
+        final List<String> actual = fastProperties.getFastProperties(ImmutableList.of("analyzed", "propertyIndex"));
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getDeltaProperties() {
+        final FastProperties fastProperties = ctx.getService(FastProperties.class);
+
+        final Collection<String> fast = ImmutableList.of(
+                "./jcr:content/one",
+                "./jcr:content/two",
+                "./jcr:content/three",
+                "./jcr:content/four",
+                "./jcr:content/five");
+
+        final Collection<String> other = ImmutableList.of(
+                "jcr:content/one",
+                "jcr:content/two",
+                "jcr:content/three",
+                "jcr:content/five");
+
+        final List<String> actual = fastProperties.getDeltaProperties(fast, other);
+
+        assertEquals(1, actual.size());
+        assertEquals("./jcr:content/four", actual.get(0));
+    }
+
+    @Test
+    public void getFastLabel() {
+        final FastProperties fastProperties = ctx.getService(FastProperties.class);
+
+        final String expected = FastProperties.FAST + "  I'm a fast property";
+        final String actual = fastProperties.getFastLabel("I'm a fast property");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getSlowLabel() {
+        final FastProperties fastProperties = ctx.getService(FastProperties.class);
+
+        final String expected = FastProperties.SLOW + "  I'm a slow property";
+        final String actual = fastProperties.getSlowLabel("I'm a slow property");
+
+        assertEquals(expected, actual);
+    }
+}

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PredicateEvaluatorUtilTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PredicateEvaluatorUtilTest.java
@@ -1,0 +1,65 @@
+package com.adobe.aem.commons.assetshare.search.impl.predicateevaluators;
+
+import com.day.cq.search.Predicate;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PredicateEvaluatorUtilTest {
+
+    @Test
+    public void getValues() {
+        Predicate predicate = new Predicate("testing");
+
+        predicate.set("test", "zero");
+        predicate.set("1_test", "one");
+        predicate.set("2_test", "two");
+        predicate.set("_test", "no");
+        predicate.set("incorrect", "no");
+        predicate.set("1_incorrect", "no");
+
+        final List<String> actuals = PredicateEvaluatorUtil.getValues(predicate, "test");
+
+        assertEquals(actuals.size(), 3);
+
+        assertTrue(actuals.contains("zero"));
+        assertTrue(actuals.contains("one"));
+        assertTrue(actuals.contains("two"));
+    }
+
+
+    @Test
+    public void getValues_nullify() {
+        Predicate predicate = new Predicate("testing");
+
+        predicate.set("test", "zero");
+        predicate.set("1_test", "one");
+        predicate.set("2_test", "two");
+        predicate.set("_test", "no");
+        predicate.set("incorrect", "no");
+        predicate.set("1_incorrect", "no");
+
+        final List<String> actuals = PredicateEvaluatorUtil.getValues(predicate, "test", true);
+
+        assertEquals(actuals.size(), 3);
+
+        assertTrue(actuals.contains("zero"));
+        assertTrue(actuals.contains("one"));
+        assertTrue(actuals.contains("two"));
+
+        assertNull(predicate.get("test"));
+        assertNull(predicate.get("1_test"));
+        assertNull(predicate.get("2_test"));
+
+        assertNotNull(predicate.get("_test"));
+        assertNotNull(predicate.get("incorrect"));
+        assertNotNull(predicate.get("1_incorrect"));
+
+    }
+}

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PropertyValuesPredicateEvaluatorTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PropertyValuesPredicateEvaluatorTest.java
@@ -1,0 +1,318 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2018 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.adobe.aem.commons.assetshare.search.impl.predicateevaluators;
+
+import com.day.cq.search.Predicate;
+import com.day.cq.search.eval.FulltextPredicateEvaluator;
+import com.day.cq.search.eval.JcrPropertyPredicateEvaluator;
+import com.day.cq.search.eval.PredicateEvaluator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.wcm.testing.mock.aem.junit.AemContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PropertyValuesPredicateEvaluatorTest {
+
+    private PropertyValuesPredicateEvaluator propertyValuesPredicateEvaluator;
+
+    private Predicate predicate;
+
+    @Rule
+    public AemContext ctx = new AemContext();
+
+    @Before
+    public void setUp() {
+        predicate = new Predicate("test", "propertyvalues");
+
+        ctx.registerInjectActivateService(new PropertyValuesPredicateEvaluator());
+
+        propertyValuesPredicateEvaluator = (PropertyValuesPredicateEvaluator) ctx.getService(PredicateEvaluator.class);
+    }
+
+
+    @Test
+    public void buildPredicate_WithAlreadyBuiltPredicate() {
+        predicate.set("__asset-share-commons--predicate-built", "true");
+
+        final Predicate actual = propertyValuesPredicateEvaluator.buildPredicate(predicate);
+
+        assertSame(predicate, actual);
+        assertEquals(predicate, actual);
+    }
+
+    @Test
+    public void buildPredicate_WithNoneDelimiter() {
+        final Map<String, String> expectedParams = ImmutableMap.<String, String>builder()
+                .put(JcrPropertyPredicateEvaluator.OPERATION, JcrPropertyPredicateEvaluator.OP_EQUALS)
+                .put(JcrPropertyPredicateEvaluator.PROPERTY, "jcr:content/metadata/property")
+                .put("0_" + JcrPropertyPredicateEvaluator.VALUE, "foo bar")
+                .put("1_" + JcrPropertyPredicateEvaluator.VALUE, "zip zap")
+                .put("__asset-share-commons--predicate-built", "true")
+                .build();
+
+        predicate.set("operation", "equals");
+        predicate.set("property", "jcr:content/metadata/property");
+        predicate.set("values", "foo bar");
+        predicate.set("1_values", "zip zap");
+        predicate.set("delimiter", "_NONE");
+
+        final Predicate actual = propertyValuesPredicateEvaluator.buildPredicate(predicate);
+
+        assertEquals("property", actual.getType());
+        assertEquals(expectedParams, actual.getParameters());
+        assertEquals("test", actual.getName());
+    }
+
+    @Test
+    public void buildPredicate_AsPropertyOperation() {
+        final Map<String, String> expectedParams = ImmutableMap.<String, String>builder()
+                .put(JcrPropertyPredicateEvaluator.OPERATION, JcrPropertyPredicateEvaluator.OP_EQUALS)
+                .put(JcrPropertyPredicateEvaluator.PROPERTY, "jcr:content/metadata/property")
+                .put("0_" + JcrPropertyPredicateEvaluator.VALUE, "foo")
+                .put("1_" + JcrPropertyPredicateEvaluator.VALUE, "bar")
+                .put("2_" + JcrPropertyPredicateEvaluator.VALUE, "zip")
+                .put("3_" + JcrPropertyPredicateEvaluator.VALUE, "zap")
+                .put("__asset-share-commons--predicate-built", "true")
+                .build();
+
+        predicate.set("operation", "equals");
+        predicate.set("property", "jcr:content/metadata/property");
+        predicate.set("values", "foo bar");
+        predicate.set("1_values", "zip zap");
+        predicate.set("99_delimiter", "__WS");
+
+        final Predicate actual = propertyValuesPredicateEvaluator.buildPredicate(predicate);
+
+        assertEquals("property", actual.getType());
+        assertEquals(expectedParams, actual.getParameters());
+        assertEquals("test", actual.getName());
+    }
+
+    @Test
+    public void buildPredicate_AsContainsOperation() {
+        final Map<String, String> expectedParams = ImmutableMap
+                .of(
+                        FulltextPredicateEvaluator.FULLTEXT, "*foo* OR *bar*",
+                        FulltextPredicateEvaluator.REL_PATH, "jcr:content/metadata/@property",
+                        "__asset-share-commons--predicate-built", "true"
+                );
+
+        predicate.set("operation", "contains");
+        predicate.set("property", "jcr:content/metadata/property");
+        predicate.set("values", "foo, bar");
+
+        final Predicate actual = propertyValuesPredicateEvaluator.buildPredicate(predicate);
+
+        assertEquals("fulltext", actual.getType());
+        assertEquals(expectedParams, actual.getParameters());
+        assertEquals("test", actual.getName());
+    }
+
+    @Test
+    public void buildPredicate_AsStartsWithOperation() {
+        final Map<String, String> expectedParams = ImmutableMap
+                .of(
+                        FulltextPredicateEvaluator.FULLTEXT, "foo* OR bar* OR zip* OR zap*",
+                        FulltextPredicateEvaluator.REL_PATH, "jcr:content/metadata/@property",
+                        "__asset-share-commons--predicate-built", "true"
+                );
+
+        predicate.set("operation", "startsWith");
+        predicate.set("property", "jcr:content/metadata/property");
+        predicate.set("values", "foo, bar");
+        predicate.set("1_values", "zip, zap");
+
+        final Predicate actual = propertyValuesPredicateEvaluator.buildPredicate(predicate);
+
+        assertEquals("fulltext", actual.getType());
+        assertEquals(expectedParams, actual.getParameters());
+        assertEquals("test", actual.getName());
+    }
+
+
+    @Test
+    public void buildPredicate_DefaultDelimiter() {
+        predicate.set("values", "foo, bar");
+        predicate.set("1_values", "zip,zap");
+
+        Predicate actual = propertyValuesPredicateEvaluator.buildPredicate(predicate);
+
+        assertEquals("foo", actual.get("0_value"));
+        assertEquals("bar", actual.get("1_value"));
+        assertEquals("zip", actual.get("2_value"));
+        assertEquals("zap", actual.get("3_value"));
+    }
+
+    @Test
+    public void buildPredicate_CustomDelimiter() {
+        predicate.set("values", "foo?bar");
+        predicate.set("delimiter", "?");
+
+        Predicate actual = propertyValuesPredicateEvaluator.buildPredicate(predicate);
+
+        assertEquals("foo", actual.get("0_value"));
+        assertEquals("bar", actual.get("1_value"));
+    }
+
+
+    @Test
+    public void buildPredicate_MultiDelimiters() {
+        predicate.set("values", "foo?bar, zip, zap");
+        predicate.set("1_values", "cat,dog,bird?turtle horse,cow      chicken");
+        predicate.set("delimiter", "?");
+        predicate.set("1_delimiter", ",");
+        predicate.set("2_delimiter", "__WS");
+
+        Predicate actual = propertyValuesPredicateEvaluator.buildPredicate(predicate);
+
+        assertEquals("foo", actual.get("0_value"));
+        assertEquals("bar", actual.get("1_value"));
+        assertEquals("zip", actual.get("2_value"));
+        assertEquals("zap", actual.get("3_value"));
+        assertEquals("cat", actual.get("4_value"));
+        assertEquals("dog", actual.get("5_value"));
+        assertEquals("bird", actual.get("6_value"));
+        assertEquals("turtle", actual.get("7_value"));
+        assertEquals("horse", actual.get("8_value"));
+        assertEquals("cow", actual.get("9_value"));
+        assertEquals("chicken", actual.get("10_value"));
+    }
+
+    @Test
+    public void buildPredicate_WhitespaceDelimiters() {
+        predicate.set("values", "foo" + System.lineSeparator() + "bar zip   zap");
+        predicate.set("delimiter", "__WS");
+
+        Predicate actual = propertyValuesPredicateEvaluator.buildPredicate(predicate);
+
+        assertEquals("foo", actual.get("0_value"));
+        assertEquals("bar", actual.get("1_value"));
+        assertEquals("zip", actual.get("2_value"));
+        assertEquals("zap", actual.get("3_value"));
+    }
+
+    @Test
+    public void getValues() {
+        List<String> expected = new ArrayList<>();
+        expected.add("one");
+        expected.add("two");
+        expected.add("three");
+
+        List<String> delimiters = new ArrayList<>();
+        delimiters.add(",");
+
+        List<String> actual = propertyValuesPredicateEvaluator.getValues("one,two,three", delimiters);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getValues_MultipleDelimiters() {
+        List<String> expected = new ArrayList<>();
+        expected.add("one");
+        expected.add("two");
+        expected.add("three");
+        expected.add("four");
+        expected.add("five");
+
+        List<String> delimiters = new ArrayList<>();
+        delimiters.add(",");
+        delimiters.add("\\?");
+
+        List<String> actual = propertyValuesPredicateEvaluator.getValues("one?two,three?four?,five", delimiters);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getValues_WhitespaceDelimiters() {
+        List<String> expected = ImmutableList.of("one", "two", "three", "four", "five");
+
+        List<String> delimiters = new ArrayList<>();
+        delimiters.add("\\s");
+
+        List<String> actual = propertyValuesPredicateEvaluator.getValues("one    two  " + System.lineSeparator()  + "  three four      five", delimiters);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getDelimiters() {
+        predicate.set("delimiter", ",");
+        predicate.set("0_delimiter", "?");
+        predicate.set("1_delimiter", "/");
+        predicate.set("2_delimiter", "\\");
+        predicate.set("_delimiter", "no");
+        predicate.set("incorrect", "no");
+        predicate.set("1_incorrect", "no");
+
+
+        List<String> actual = propertyValuesPredicateEvaluator.getDelimiters(predicate);
+        assertEquals(4, actual.size());
+
+        assertTrue(actual.contains(Pattern.quote(",")));
+        assertTrue(actual.contains(Pattern.quote("?")));
+        assertTrue(actual.contains(Pattern.quote("/")));
+        assertTrue(actual.contains(Pattern.quote("\\")));
+
+        assertFalse(actual.contains("no"));
+    }
+
+    @Test
+    public void getDelimiters_Default() {
+        List<String> actual = propertyValuesPredicateEvaluator.getDelimiters(predicate);
+        assertEquals(1, actual.size());
+
+        assertTrue(actual.contains(Pattern.quote(",")));
+    }
+
+    @Test
+    public void getPredicateEvaluator_AsPropertyPredicate() {
+        predicate.set("operation", "equals");
+        PredicateEvaluator actual = propertyValuesPredicateEvaluator.getPredicateEvaluator(predicate);
+
+        assertTrue(actual instanceof JcrPropertyPredicateEvaluator);
+    }
+
+    @Test
+    public void getPredicateEvaluator_AsFulltextPredicate() {
+        predicate.set("operation", "startsWith");
+        PredicateEvaluator actual = propertyValuesPredicateEvaluator.getPredicateEvaluator(predicate);
+
+        assertTrue(actual instanceof FulltextPredicateEvaluator);
+
+        predicate.set("operation", "contains");
+        actual = propertyValuesPredicateEvaluator.getPredicateEvaluator(predicate);
+
+        assertTrue(actual instanceof FulltextPredicateEvaluator);
+    }
+}

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PropertyValuesPredicateEvaluatorTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PropertyValuesPredicateEvaluatorTest.java
@@ -32,9 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.*;
@@ -71,13 +69,15 @@ public class PropertyValuesPredicateEvaluatorTest {
 
     @Test
     public void buildPredicate_WithNoneDelimiter() {
-        final Map<String, String> expectedParams = ImmutableMap.<String, String>builder()
-                .put(JcrPropertyPredicateEvaluator.OPERATION, JcrPropertyPredicateEvaluator.OP_EQUALS)
-                .put(JcrPropertyPredicateEvaluator.PROPERTY, "jcr:content/metadata/property")
-                .put("0_" + JcrPropertyPredicateEvaluator.VALUE, "foo bar")
-                .put("1_" + JcrPropertyPredicateEvaluator.VALUE, "zip zap")
-                .put("__asset-share-commons--predicate-built", "true")
-                .build();
+        final Map<String, String> expectedParams = new HashMap<>();
+        expectedParams.put(JcrPropertyPredicateEvaluator.OPERATION, JcrPropertyPredicateEvaluator.OP_EQUALS);
+        expectedParams.put(JcrPropertyPredicateEvaluator.PROPERTY, "jcr:content/metadata/property");
+        expectedParams.put("0_" + JcrPropertyPredicateEvaluator.VALUE, "foo bar");
+        expectedParams.put("1_" + JcrPropertyPredicateEvaluator.VALUE, "zip zap");
+        expectedParams.put("__asset-share-commons--predicate-built", "true");
+        expectedParams.put("values", null);
+        expectedParams.put("1_values", null);
+        expectedParams.put("delimiter", null);
 
         predicate.set("operation", "equals");
         predicate.set("property", "jcr:content/metadata/property");
@@ -87,22 +87,25 @@ public class PropertyValuesPredicateEvaluatorTest {
 
         final Predicate actual = propertyValuesPredicateEvaluator.buildPredicate(predicate);
 
-        assertEquals("property", actual.getType());
+        assertEquals("propertyvalues", actual.getType());
         assertEquals(expectedParams, actual.getParameters());
         assertEquals("test", actual.getName());
     }
 
     @Test
     public void buildPredicate_AsPropertyOperation() {
-        final Map<String, String> expectedParams = ImmutableMap.<String, String>builder()
-                .put(JcrPropertyPredicateEvaluator.OPERATION, JcrPropertyPredicateEvaluator.OP_EQUALS)
-                .put(JcrPropertyPredicateEvaluator.PROPERTY, "jcr:content/metadata/property")
-                .put("0_" + JcrPropertyPredicateEvaluator.VALUE, "foo")
-                .put("1_" + JcrPropertyPredicateEvaluator.VALUE, "bar")
-                .put("2_" + JcrPropertyPredicateEvaluator.VALUE, "zip")
-                .put("3_" + JcrPropertyPredicateEvaluator.VALUE, "zap")
-                .put("__asset-share-commons--predicate-built", "true")
-                .build();
+        final Map<String, String> expectedParams = new HashMap<>();
+        expectedParams.put(JcrPropertyPredicateEvaluator.OPERATION, JcrPropertyPredicateEvaluator.OP_EQUALS);
+        expectedParams.put(JcrPropertyPredicateEvaluator.PROPERTY, "jcr:content/metadata/property");
+        expectedParams.put("0_" + JcrPropertyPredicateEvaluator.VALUE, "foo");
+        expectedParams.put("1_" + JcrPropertyPredicateEvaluator.VALUE, "bar");
+        expectedParams.put("2_" + JcrPropertyPredicateEvaluator.VALUE, "zip");
+        expectedParams.put("3_" + JcrPropertyPredicateEvaluator.VALUE, "zap");
+        expectedParams.put("__asset-share-commons--predicate-built", "true");
+        expectedParams.put("operation", "equals");
+        expectedParams.put("values", null);
+        expectedParams.put("1_values", null);
+        expectedParams.put("99_delimiter", null);
 
         predicate.set("operation", "equals");
         predicate.set("property", "jcr:content/metadata/property");
@@ -112,19 +115,20 @@ public class PropertyValuesPredicateEvaluatorTest {
 
         final Predicate actual = propertyValuesPredicateEvaluator.buildPredicate(predicate);
 
-        assertEquals("property", actual.getType());
+        assertEquals("propertyvalues", actual.getType());
         assertEquals(expectedParams, actual.getParameters());
         assertEquals("test", actual.getName());
     }
 
     @Test
     public void buildPredicate_AsContainsOperation() {
-        final Map<String, String> expectedParams = ImmutableMap
-                .of(
-                        FulltextPredicateEvaluator.FULLTEXT, "*foo* OR *bar*",
-                        FulltextPredicateEvaluator.REL_PATH, "jcr:content/metadata/@property",
-                        "__asset-share-commons--predicate-built", "true"
-                );
+        final Map<String, String> expectedParams = new HashMap<>();
+        expectedParams.put(FulltextPredicateEvaluator.FULLTEXT, "*foo* OR *bar*");
+        expectedParams.put(FulltextPredicateEvaluator.REL_PATH, "jcr:content/metadata/@property");
+        expectedParams.put("__asset-share-commons--predicate-built", "true");
+        expectedParams.put("values", null);
+        expectedParams.put("property", null);
+        expectedParams.put("operation", null);
 
         predicate.set("operation", "contains");
         predicate.set("property", "jcr:content/metadata/property");
@@ -132,19 +136,21 @@ public class PropertyValuesPredicateEvaluatorTest {
 
         final Predicate actual = propertyValuesPredicateEvaluator.buildPredicate(predicate);
 
-        assertEquals("fulltext", actual.getType());
+        assertEquals("propertyvalues", actual.getType());
         assertEquals(expectedParams, actual.getParameters());
         assertEquals("test", actual.getName());
     }
 
     @Test
     public void buildPredicate_AsStartsWithOperation() {
-        final Map<String, String> expectedParams = ImmutableMap
-                .of(
-                        FulltextPredicateEvaluator.FULLTEXT, "foo* OR bar* OR zip* OR zap*",
-                        FulltextPredicateEvaluator.REL_PATH, "jcr:content/metadata/@property",
-                        "__asset-share-commons--predicate-built", "true"
-                );
+        final Map<String, String> expectedParams = new HashMap<>();
+        expectedParams.put(FulltextPredicateEvaluator.FULLTEXT, "foo* OR bar* OR zip* OR zap*");
+        expectedParams.put(FulltextPredicateEvaluator.REL_PATH, "jcr:content/metadata/@property");
+        expectedParams.put("__asset-share-commons--predicate-built", "true");
+        expectedParams.put("values", null);
+        expectedParams.put("property", null);
+        expectedParams.put("operation", null);
+        expectedParams.put("1_values", null);
 
         predicate.set("operation", "startsWith");
         predicate.set("property", "jcr:content/metadata/property");
@@ -153,7 +159,7 @@ public class PropertyValuesPredicateEvaluatorTest {
 
         final Predicate actual = propertyValuesPredicateEvaluator.buildPredicate(predicate);
 
-        assertEquals("fulltext", actual.getType());
+        assertEquals("propertyvalues", actual.getType());
         assertEquals(expectedParams, actual.getParameters());
         assertEquals("test", actual.getName());
     }

--- a/core/src/test/resources/com/adobe/aem/commons/assetshare/search/impl/FastPropertiesImplTest.json
+++ b/core/src/test/resources/com/adobe/aem/commons/assetshare/search/impl/FastPropertiesImplTest.json
@@ -1,0 +1,28 @@
+{
+  "vanilla": {
+    "jcr:primaryType": "nt:unstructured",
+    "name": "jcr:content/vanilla"
+  },
+  "property-index-rule": {
+    "jcr:primaryType": "nt:unstructured",
+    "name": "jcr:content/propertyIndexRule",
+    "propertyIndex": true
+  },
+  "analyzed-index-rule": {
+    "jcr:primaryType": "nt:unstructured",
+    "name": "jcr:content/analyzedIndexRule",
+    "analyzed": true
+  },
+  "property-and-analyzed-index-rule": {
+    "jcr:primaryType": "nt:unstructured",
+    "name": "jcr:content/propertyAndAnalyzedIndexRule",
+    "analyzed": true,
+    "propertyIndex": true
+  },
+  "duplicate": {
+    "jcr:primaryType": "nt:unstructured",
+    "name": "jcr:content/propertyAndAnalyzedIndexRule",
+    "analyzed": true,
+    "propertyIndex": true
+  }
+}

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/events.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/events.js
@@ -29,6 +29,7 @@ AssetShare.Events = {
 
     SEARCH_BEGIN: "asset-share-commons.search.begin",
     SEARCH_END: "asset-share-commons.search.end",
+    SEARCH_INVALID: "asset-share-commons.search.invalid",
 
     MODAL_SHOWN: "asset-share-commons.modal.shown"
 };

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/search/search-form.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/search/search-form.js
@@ -29,13 +29,17 @@ AssetShare.Search.Form = function (ns) {
        return "asset-share-commons__form-id__1";
     }
 
+    function _htmlForm() {
+        return $('form[id="' + getId() + '"]');
+    }
+
     /** Operations **/
     function getUrl() {
         return url;
     }
 
     function reset() {
-        formData = new ns.FormData($('[form="' + getId() + '"]'));
+        formData = new ns.FormData(_htmlForm());
     }
 
     /** Getter Or Setter Methods **/
@@ -126,6 +130,49 @@ AssetShare.Search.Form = function (ns) {
         return buildFormData(formData, event).serialize();
     }
 
+    function _valid(formToValidate) {
+        var valid = true,
+            visible = true;
+
+        formData.getAll().forEach(function(formEntry) {
+           var inputElement = $('[name="' + formEntry.name + '"][form="' + getId() + '"]'),
+               inputElementValid,
+               inputElementValidationMessage;
+
+           if (inputElement && inputElement[0]) {
+               inputElementValid = inputElement[0].checkValidity();
+
+               if (!inputElementValid) {
+                   valid = false;
+                   visible = visible && inputElement.is(':visible');
+
+                   inputElementValidationMessage = inputElement.data('asset-share-input-validation-message');
+                   if (inputElementValidationMessage) {
+                       inputElement[0].setCustomValidity(inputElementValidationMessage);
+                   }
+               }
+           }
+        });
+
+        if (!valid && visible) {
+            // Only trigger if all erroring fields are visible (if not a JS error is thrown)
+            $('<input type="submit">').hide().appendTo(_htmlForm()).click().remove();
+        }
+
+        return valid;
+    }
+
+    function submit(serializationType, resetForm, success) {
+        var formToSubmit = serializeFor(serializationType, resetForm);
+
+        if (_valid(formToSubmit)) {
+            $.when($.get(getUrl(), formToSubmit)).then(success);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     function init() {
         // On init, the DOM is king as its populated by the server page load
         url = ns.Data.attr(ns.Elements.element("form"), "action");
@@ -139,7 +186,8 @@ AssetShare.Search.Form = function (ns) {
     return {
         url: getUrl,
         serializeFor: serializeFor,
-        id: getId
+        id: getId,
+        submit: submit
     };
 };
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/search/search.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/search/search.js
@@ -72,8 +72,12 @@ AssetShare.Search = (function (window, $, ns, ajax) {
         }
         if (!running) {
             running = true;
-            trigger(ns.Events.SEARCH_BEGIN, [EVENT_SEARCH_TYPE_FULL]);
-            $.when($.get(form.url(), form.serializeFor(ACTION_SEARCH, true))).then(processSearch);
+            if (form.submit(ACTION_SEARCH, true, processSearch)) {
+                trigger(ns.Events.SEARCH_BEGIN, [EVENT_SEARCH_TYPE_FULL]);
+            } else {
+                trigger(ns.Events.SEARCH_INVALID, [EVENT_SEARCH_TYPE_FULL]);
+                running = false;
+            }
         }
     }
 
@@ -83,8 +87,12 @@ AssetShare.Search = (function (window, $, ns, ajax) {
         }
         if (!running) {
             running = true;
-            trigger(ns.Events.SEARCH_BEGIN, [EVENT_SEARCH_TYPE_LOAD_MORE]);
-            $.when($.get(form.url(), form.serializeFor(ACTION_LOAD_MORE))).then(processLoadMore);
+            if (form.submit(ACTION_LOAD_MORE, false, processLoadMore)) {
+                trigger(ns.Events.SEARCH_BEGIN, [EVENT_SEARCH_TYPE_LOAD_MORE]);
+            } else {
+                trigger(ns.Events.SEARCH_INVALID, [EVENT_SEARCH_TYPE_LOAD_MORE]);
+                running = false;
+            }
         }
     }
 
@@ -94,8 +102,12 @@ AssetShare.Search = (function (window, $, ns, ajax) {
         }
         if (!running) {
             running = true;
-            trigger(ns.Events.SEARCH_BEGIN, [EVENT_SEARCH_TYPE_FULL]);
-            $.when($.get(form.url(), form.serializeFor(ACTION_SORT))).then(processSearch);
+            if (form.submit(ACTION_SORT, false, processSearch)) {
+                trigger(ns.Events.SEARCH_BEGIN, [EVENT_SEARCH_TYPE_FULL]);
+            } else {
+                trigger(ns.Events.SEARCH_INVALID, [EVENT_SEARCH_TYPE_FULL]);
+                running = false;
+            }
         }
     }
 
@@ -103,9 +115,14 @@ AssetShare.Search = (function (window, $, ns, ajax) {
         e.preventDefault();
         if (!running) {
             running = true;
-            trigger(ns.Events.SEARCH_BEGIN, [EVENT_SEARCH_TYPE_FULL]);
+
             ns.Data.val("layout", $(this).val());
-            $.when($.get(form.url(), form.serializeFor(ACTION_SWITCH_LAYOUT))).then(processSearch);
+            if (form.submit(ACTION_SWITCH_LAYOUT, false, processSearch)) {
+                trigger(ns.Events.SEARCH_BEGIN, [EVENT_SEARCH_TYPE_FULL]);
+            } else {
+                trigger(ns.Events.SEARCH_INVALID, [EVENT_SEARCH_TYPE_FULL]);
+                running = false;
+            }
         }
     }
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/less/main.less
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/less/main.less
@@ -18,6 +18,14 @@
 
 @import (once) "variables.less";
 
-.hidden {
-    display: none !important;
+#asset-share-commons {
+    .hidden {
+        display: none !important;
+    }
+
+    select:invalid,
+    textarea:invalid,
+    input:invalid {
+        border: solid 1px red;
+    }
 }

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/.content.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2017]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="cq:Component"
+          jcr:title="Free-form Text"
+          jcr:description="Allows a user to filter search results by a jcr metadata property by providing free-form text."
+          cq:icon="textEdit"
+          componentGroup="Asset Share Commons - Search"
+          generatePredicateGroupId="{Boolean}true"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/_cq_dialog/.content.xml
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2017]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:primaryType="nt:unstructured"
+          jcr:title="Free-form Text Filter"
+          sling:resourceType="cq/gui/components/authoring/dialog"
+          extraClientlibs="[core.wcm.components.form.options.v1.editor,asset-share-commons.author.dialog,assetshare.editor.components.search.freeform-text]"
+          helpPath="https://www.adobe.com/go/aem_cmp_form_options_v1">
+    <content
+            granite:class="cmp-search-freeform-text--editor cmp-options--editor-v1"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <options
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                    margin="{Boolean}true">
+                <items jcr:primaryType="nt:unstructured">
+                    <columns
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="granite/ui/components/coral/foundation/container">
+                        <items jcr:primaryType="nt:unstructured">
+                            <dialog
+                                    granite:class="foundation-layout-util-vmargin"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <tabs
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/tabs"
+                                            maxmized="{Boolean}true">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <tab1
+                                                    jcr:primaryType="nt:unstructured"
+                                                    jcr:title="Filter"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                                    margin="{Boolean}true">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <column
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/container">
+                                                        <items jcr:primaryType="nt:unstructured">
+
+                                                            <title
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                                    fieldDescription="Legend to describe the role of the field."
+                                                                    fieldLabel="Title"
+                                                                    name="./jcr:title"
+                                                                    required="{Boolean}true"/>
+
+                                                            <placeholder
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                                    fieldDescription="Placeholder text."
+                                                                    fieldLabel="Placeholder text"
+                                                                    name="./placeholder"
+                                                                    required="{Boolean}false"/>
+
+                                                            <rows
+                                                                    granite:class="cq-dialog-rows__field-set"
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                                                    fieldDescription="Number of rows this field should have. Note that > 1 rows uses a HTML textarea which does not support input validation."
+                                                                    fieldLabel="Input Field Rows"
+                                                                    name="./rows"
+                                                                    min="1"
+                                                                    required="{Boolean}true"/>
+
+                                                            <operation
+                                                                    granite:class="cmp-form-textfield-types cq-dialog-operation__value"
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:orderBefore="name"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                                    fieldLabel="Operation"
+                                                                    fieldDescription="Operation to use for searching. Note that different operations have different fast metadata properties. Please see the documentation on how to make other metadata properties fast for the selected operations."
+                                                                    name="./operation">
+                                                                <items jcr:primaryType="nt:unstructured">
+                                                                    <equals
+                                                                            jcr:primaryType="nt:unstructured"
+                                                                            text="Equals"
+                                                                            value="equals"/>
+                                                                    <starts-with
+                                                                            jcr:primaryType="nt:unstructured"
+                                                                            text="Starts with"
+                                                                            value="startsWith"/>
+                                                                    <contains
+                                                                            jcr:primaryType="nt:unstructured"
+                                                                            text="Contains"
+                                                                            value="contains"/>
+                                                                </items>
+                                                            </operation>
+
+                                                            <property
+                                                                    granite:class="cq-dialog-property__field-set"
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                                    emptyText="Select an Asset Metadata Property"
+                                                                    fieldDescription="A list of available properties. The lightning bolt denotes fast search restrictions for the selected operation."
+                                                                    fieldLabel="Metadata Property"
+                                                                    sling:orderBefore="name"
+                                                                    indexRuleCapabilities="[propertyIndex]"
+                                                                    name="./property">
+                                                                <datasource
+                                                                        jcr:primaryType="nt:unstructured"
+                                                                        sling:resourceType="asset-share-commons/data-sources/filterable-properties"/>
+                                                            </property>
+
+                                                            <analzyed-property
+                                                                    granite:class="cq-dialog-analyzed-property__field-set"
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                                    emptyText="Select an Asset Metadata Property"
+                                                                    fieldDescription="A list of available properties. The lightning bolt denotes fast search restrictions for the selected operation."
+                                                                    fieldLabel="Metadata Property"
+                                                                    sling:orderBefore="name"
+                                                                    indexRuleCapabilities="[analyzed]"
+                                                                    name="./property">
+                                                                <datasource
+                                                                        jcr:primaryType="nt:unstructured"
+                                                                        sling:resourceType="asset-share-commons/data-sources/filterable-properties"/>
+                                                            </analzyed-property>
+
+
+                                                            <input-validation-min-length
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                                                    fieldDescription="Minimum number of characters allowed. If the operation `Starts with` is selected, a minimum of 3 is enforced for this field for performance reasons"
+                                                                    fieldLabel="Minimum Input Length"
+                                                                    name="./inputValidationMinLength"
+                                                                    min="0"/>
+
+                                                            <input-validation-max-length
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                                                    fieldDescription="Maximum number of characters allowed. Leave blank for no maximum,."
+                                                                    fieldLabel="Maximum Input Length"
+                                                                    min="1"
+                                                                    name="./inputValidationMaxLength"/>
+
+                                                            <input-validation-pattern
+                                                                    granite:class="cq-dialog-validation-pattern__field-set"
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                                    fieldDescription="Input validation pattern (Uses HTML5 input validation pattern syntax). Allowed delimiters must be explicitly added to the validation pattern."
+                                                                    fieldLabel="Input Validation Pattern"
+                                                                    name="./inputValidationPattern"/>
+
+                                                            <input-validation-message
+                                                                    granite:class="cq-dialog-validation-message__field-set"
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                                    fieldDescription="Input validation message to show if input validation fails. Leave blank to use browser default messages."
+                                                                    fieldLabel="Input Validation Message"
+                                                                    name="./inputValidationMessage"/>
+
+                                                            <expanded
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:orderBefore="name"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                                    fieldDescription="Select if the field set should start in an expanded state (not applicable for drop down)"
+                                                                    name="./expanded"
+                                                                    text="Start Expanded"
+                                                                    value="true"/>
+
+                                                            <delimiters
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                                                    composite="{Boolean}true"
+                                                                    fieldDescription="Strings or characters used to delimit input values. Note that 'Whitespace' matches all whitespace, including spaces, tabs and line breaks."
+                                                                    fieldLabel="Delimiters"
+                                                                    renderReadOnly="{Boolean}true">
+                                                                <field
+                                                                        granite:class="cmp-options--editor-item-multifield-composite-item coral-Well"
+                                                                        jcr:primaryType="nt:unstructured"
+                                                                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                                                                        name="./delimiters">
+                                                                    <items jcr:primaryType="nt:unstructured">
+                                                                        <option
+                                                                                granite:class="cmp-options--editor-item-multifield-composite-item-container
+
+                                                                                cq-dialog-delimiter__field-set"
+
+                                                                                jcr:primaryType="nt:unstructured"
+                                                                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                                                            <items jcr:primaryType="nt:unstructured">
+
+                                                                                <delimiter
+                                                                                        jcr:primaryType="nt:unstructured"
+                                                                                        sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                                                        granite:class="cq-dialog-delimiter__value"
+                                                                                        fieldLabel="Delimiter"
+                                                                                        name="./value">
+                                                                                    <granite:data
+                                                                                            jcr:primaryType="nt:unstructured"/>
+
+                                                                                    <items jcr:primaryType="nt:unstructured">
+
+                                                                                        <comma
+                                                                                                jcr:primaryType="nt:unstructured"
+                                                                                                text="Comma (,)"
+                                                                                                value=","/>
+
+                                                                                        <whitespace
+                                                                                                jcr:primaryType="nt:unstructured"
+                                                                                                text="Whitespace (Spaces, tabs or line breaks)"
+                                                                                                value="__WS"/>
+
+
+                                                                                        <dash
+                                                                                                jcr:primaryType="nt:unstructured"
+                                                                                                text="Dash (-)"
+                                                                                                value="-"/>
+
+                                                                                        <underscore
+                                                                                                jcr:primaryType="nt:unstructured"
+                                                                                                text="Underscore (_)"
+                                                                                                value="_"/>
+
+                                                                                        <pipe
+                                                                                                jcr:primaryType="nt:unstructured"
+                                                                                                text="Pipe (|)"
+                                                                                                value="|"/>
+
+                                                                                        <colon
+                                                                                                jcr:primaryType="nt:unstructured"
+                                                                                                text="Colon (:)"
+                                                                                                value=":"/>
+
+                                                                                        <semicolon
+                                                                                                jcr:primaryType="nt:unstructured"
+                                                                                                text="Semicolon (;)"
+                                                                                                value=";"/>
+
+                                                                                        <tilde
+                                                                                                jcr:primaryType="nt:unstructured"
+                                                                                                text="Tilde (~)"
+                                                                                                value="~"/>
+
+                                                                                        <!-- The value of this option is important as it's used in freeform-text.js for the editor -->
+                                                                                        <custom
+                                                                                                jcr:primaryType="nt:unstructured"
+                                                                                                text="Custom"
+                                                                                                value="_CUSTOM"/>
+
+                                                                                        <none
+                                                                                                jcr:primaryType="nt:unstructured"
+                                                                                                text="None (Supersedes any other selected delimiter)"
+                                                                                                value="__NONE"/>
+                                                                                    </items>
+                                                                                </delimiter>
+
+                                                                                <custom-delimiter-wrapper
+                                                                                        jcr:primaryType="nt:unstructured"
+                                                                                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                                                                                        granite:class="hide cq-dialog-delimiter__custom-value">
+                                                                                    <items jcr:primaryType="nt:unstructured">
+                                                                                        <custom-delimiter
+                                                                                                jcr:primaryType="nt:unstructured"
+                                                                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                                                                fieldLabel="Custom Delimiter"
+                                                                                                name="./customValue">
+                                                                                        </custom-delimiter>
+                                                                                    </items>
+                                                                                </custom-delimiter-wrapper>
+
+                                                                            </items>
+                                                                        </option>
+                                                                    </items>
+                                                                </field>
+                                                            </delimiters>
+
+                                                        </items>
+                                                    </column>
+                                                </items>
+                                            </tab1>
+                                            <search-behavior-tab
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/include"
+                                                    path="/apps/asset-share-commons/components/search/common/cq:dialog/tabs/search-behavior"/>
+                                        </items>
+                                    </tabs>
+                                </items>
+                            </dialog>
+                        </items>
+                    </columns>
+                </items>
+            </options>
+        </items>
+    </content>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/_cq_editConfig/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/_cq_editConfig/.content.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2017]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:EditConfig"
+    dialogLayout="fullscreen">
+    <cq:listeners
+        jcr:primaryType="cq:EditListenersConfig"
+        afterinsert="REFRESH_PAGE"
+        afteredit="REFRESH_PAGE"/>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/_cq_htmlTag/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/_cq_htmlTag/.content.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2017]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    cq:tagName="div"
+    jcr:primaryType="nt:unstructured"
+    class="cmp cmp-search-freeform-text"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/_cq_template/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/_cq_template/.content.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2018]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    autoSearch="{Boolean}false"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/clientlibs/.content.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2017]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/clientlibs/editor/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/clientlibs/editor/.content.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Asset Share Commons
+  ~
+  ~ Copyright (C) 2018 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="cq:ClientLibraryFolder"
+          categories="[assetshare.editor.components.search.freeform-text,
+                        assetshare.editor.components.search,
+                        assetshare.editor.components,
+                        assetshare.editor]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/clientlibs/editor/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/clientlibs/editor/js.txt
@@ -1,0 +1,3 @@
+#base=js
+
+freeform-text.js

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/clientlibs/editor/js/freeform-text.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/clientlibs/editor/js/freeform-text.js
@@ -1,0 +1,131 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright [2017]  Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*global
+    Granite, Coral
+ */
+(function (document, $, Coral) {
+    "use strict";
+
+    /**
+     * Show / Hide the Property field based on the dialog dropdown value.
+     *
+     */
+
+    function showHidePropertyDropdown(component, propertyTarget, analyzedPropertyTarget) {
+        var propertyComponent = propertyTarget.find('.coral-Form-field').adaptTo('foundation-field'),
+            analyzedPropertyComponent = analyzedPropertyTarget.find('.coral-Form-field').adaptTo('foundation-field'),
+            analyzed = component.value !== 'equals';
+
+        analyzedPropertyComponent.setValue(propertyComponent.getValue());
+        propertyTarget.toggleClass('hide', analyzed);
+        propertyComponent.setDisabled(analyzed);
+
+        propertyComponent.setValue(analyzedPropertyComponent.getValue());
+        analyzedPropertyTarget.toggleClass('hide',!analyzed);
+        analyzedPropertyComponent.setDisabled(!analyzed);
+    }
+
+    $(document).on("foundation-contentloaded", function (e) {
+        $(".cmp-search-freeform-text--editor coral-select.cq-dialog-operation__value", e.target).each(function (i, element) {
+            var operationField = $(element),
+                propertyFieldSet = operationField
+                    .closest('.cmp-search-freeform-text--editor')
+                    .find('.cq-dialog-property__field-set')
+                    .closest('.coral-Form-fieldwrapper'),
+            analyzedPropertyTarget = operationField
+                    .closest('.cmp-search-freeform-text--editor')
+                    .find('.cq-dialog-analyzed-property__field-set')
+                    .closest('.coral-Form-fieldwrapper');
+
+            if (operationField && propertyFieldSet && analyzedPropertyTarget) {
+                Coral.commons.ready(element, function (component) {
+                    showHidePropertyDropdown(component, propertyFieldSet, analyzedPropertyTarget);
+
+                    component.on("change", function () {
+                        showHidePropertyDropdown(component, propertyFieldSet, analyzedPropertyTarget);
+                    });
+                });
+            }
+        });
+    });
+
+
+    /**
+     * Show / Hide the Delimiter Input field based on the dialog dropdown value.
+     *
+     * Only the Custom field shows the text input allowing for the author to type in custom values.
+     */
+
+    function showHideDelimiter(component, target) {
+        target.toggleClass('hide', component.value !== '_CUSTOM');
+    }
+
+    $(document).on("foundation-contentloaded", function (e) {
+        $(".cmp-search-freeform-text--editor coral-select.cq-dialog-delimiter__value", e.target).each(function (i, element) {
+            var delimiterField = $(element),
+                fieldSet = delimiterField.closest('.cq-dialog-delimiter__field-set'),
+                customDelimiterField = fieldSet.find('.cq-dialog-delimiter__custom-value');
+
+            if (fieldSet && customDelimiterField) {
+                Coral.commons.ready(element, function (component) {
+                    showHideDelimiter(component, customDelimiterField);
+                    component.on("change", function () { showHideDelimiter(component, customDelimiterField); });
+                });
+            }
+        });
+
+
+        /**
+         * Handles show and hide of the Input Validation Field based on the # of Rows.
+         *
+         * This is because input fields only support native HTML5 pattern validation which is when rows = 1.
+         * Textareas do NOT support pattern validation; when rows > 1
+         */
+
+        function showHideValidation(component, target) {
+            target.toggleClass('hide', component.value > 1);
+        }
+
+        $('.cmp-search-freeform-text--editor .cq-dialog-rows__field-set', e.target).each(function (i, element) {
+            var rowsInputElement = $(element).find('input[type="number"]'),
+                validationPatternFieldSet = rowsInputElement
+                    .closest('.cmp-search-freeform-text--editor')
+                    .find('.cq-dialog-validation-pattern__field-set')
+                    .closest('.coral-Form-fieldwrapper'),
+                validationMessageFieldSet = rowsInputElement
+                    .closest('.cmp-search-freeform-text--editor')
+                    .find('.cq-dialog-validation-message__field-set')
+                    .closest('.coral-Form-fieldwrapper');
+
+
+            if (rowsInputElement && validationPatternFieldSet && validationMessageFieldSet) {
+                Coral.commons.ready(element, function (component) {
+                    showHideValidation(component, validationPatternFieldSet);
+                    showHideValidation(component, validationMessageFieldSet);
+
+                    component.on("change", function () {
+                        showHideValidation(component, validationPatternFieldSet);
+                        showHideValidation(component, validationMessageFieldSet);
+                    });
+                });
+            }
+        });
+
+    });
+}(document, Granite.$, Coral));

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/freeform-text.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/freeform-text.html
@@ -1,0 +1,96 @@
+<!--/*
+  ~ Asset Share Commons
+  ~
+  ~ Copyright [2017]  Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+ */-->
+
+<sly data-sly-use.predicate="com.adobe.aem.commons.assetshare.components.predicates.FreeformTextPredicate"
+     data-sly-use.placeholderTemplate="core/wcm/components/commons/v1/templates.html"
+	 data-sly-test.ready="${predicate.ready}">
+
+	<!--/* Property */-->
+	<input type="hidden"
+		   form="${predicate.formId}"
+		   name="${predicate.group}.${predicate.name}.property"
+		   value="${predicate.property}"
+		   data-asset-share-predicate-id="${predicate.id}"/>
+
+	<!--/* Delimiters */-->
+	<sly data-sly-list.delimiter="${predicate.delimiters}">
+		<input type="hidden"
+			   form="${predicate.formId}"
+			   name="${predicate.group}.${predicate.name}.${delimiterList.index}_delimiter"
+			   value="${delimiter}"
+			   data-asset-share-predicate-id="${predicate.id}"/>
+	</sly>
+
+	<!--/* Operations */-->
+
+	<input data-sly-test="${predicate.hasOperation}"
+		   type="hidden"
+		   name="${predicate.group}.${predicate.name}.operation"
+		   value="${predicate.operation}"
+		   form="${predicate.formId}"
+		   data-asset-share-predicate-id="${predicate.id}"/>
+
+
+
+	<div class="ui form">
+		<div class="ui fluid styled accordion field">
+
+			<div class="${predicate.expanded ? 'active' : ''} title right">
+				<i class="dropdown icon"></i>
+				${predicate.title}
+			</div>
+
+			<div    class="${predicate.expanded ? 'active' : ''} content field"
+					data-asset-share-id="${predicate.id}__fields"
+					data-asset-share-update-method="${predicate.componentUpdateMethod}">
+
+				<div class="field">
+                        <textarea type="text"
+                                  placeholder="${properties['placeholder']}"
+                                  minlength="${predicate.inputValidationMinLength}"
+                                  maxlength="${predicate.inputValidationMaxLength}"
+                                  pattern="${predicate.inputValidationPattern}"
+                                  name="${predicate.group}.${predicate.name}.values"
+                                  form="${predicate.formId}"
+                                  for="${predicate.id}"
+                                  rows="${predicate.rows}"
+                                  class="cmp-freeform-text__input cmp-freeform-text__input--textarea"
+                                  data-asset-share-input-validation-message="${predicate.inputValidationMessage}"
+                                  data-asset-share-search-on="${predicate.autoSearch ? 'change' : ''}"
+                                  data-sly-test.isTextArea="${predicate.rows > 1}">${predicate.initialValue}</textarea>
+
+                        <input type="text"
+                               placeholder="${properties['placeholder']}"
+                               minlength="${predicate.inputValidationMinLength}"
+                               maxlength="${predicate.inputValidationMaxLength}"
+                               pattern="${predicate.inputValidationPattern}"
+                               name="${predicate.group}.${predicate.name}.values"
+                               value="${predicate.initialValue}"
+                               form="${predicate.formId}"
+                               for="${predicate.id}"
+                               class="cmp-freeform-text__input"
+                               data-asset-share-input-validation-message="${predicate.inputValidationMessage}"
+                               data-asset-share-search-on="${predicate.autoSearch ? 'change' : ''}"
+                               data-sly-test="${!isTextArea}"/>
+				</div>
+			</div>
+		</div>
+	</div>
+
+</sly>
+<sly data-sly-call="${placeholderTemplate.placeholder @ isEmpty=!ready}"></sly>


### PR DESCRIPTION
This fixes the merged and reverted #351.

It appears there may have been a change in AEM 6.5 QueryBuilder API that requires predicate objects to be modified in place rather than using a modified new predicate object -- or at least this is how I was able to work around the issue.

------

Added new search component that supports free-form text entry. This search component exposes an HTML input field (when Input Field Rows == 1) or an HTML Textarea (Input Field Rows > 1) that allows the user to enter a delimited list of values to search for (using operations: equals, starts with, contains).

Since equals and starts with/contains have different index rule requirements, different Metadata property data sources are used, each indicating the fast properties based on the selected Operation.

![](https://user-images.githubusercontent.com/1451868/50542242-bdd6b980-0b86-11e9-9549-3b3d8b89b18a.png)

![](https://user-images.githubusercontent.com/1451868/50542245-d2b34d00-0b86-11e9-8f81-a8a4afeba963.png)

This PR includes adjustments to the following existing behavior to support the new component:
* Enable HTML Input validations in search-form.js
* Updated PropertyValuesPredicateEvaluator to support parameterized/custom delimiters
* Updated PropertyValuesPredicateEvaluator to support Starts With and Contains operations (requiring a min of 3 chars) using Fulltext QB predicate.
* Ability to parameterized Fast Properties based on the Dialog configuration.