### PR TITLE
Feature/398 update

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -182,7 +182,7 @@
                     <instructions>
                         <Import-Package>
                             org.apache.sling.xss;version="[1.2,3)",
-
+                            javax.annotation;version=0.0.0,
                             *
                         </Import-Package>
                         <Embed-Dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -182,6 +182,7 @@
                     <instructions>
                         <Import-Package>
                             org.apache.sling.xss;version="[1.2,3)",
+                            javax.inject;version=0.0.0,
                             javax.annotation;version=0.0.0,
                             *
                         </Import-Package>


### PR DESCRIPTION
Fixes an issue with AEM versions < 6.5 following update for adding support to JDK 11.

Before the update, the ASC bundle (from develop) was in an installed state on AEM 6.4 and 6.3:
![image](https://user-images.githubusercontent.com/8974514/59217234-57f94f80-8b72-11e9-8a1a-a505841ca066.png)
 
Added the import any version of javax.inject and javax.annotation to allow running on multiple versions of AEM. Matches the import package instructions used in the AEM archetype: https://github.com/adobe/aem-project-archetype/blob/master/src/main/archetype/core/pom.xml#L61