### PR TITLE
Fix/412 - Search Results dialog not opening due to MetadataSchemaPropert…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 0390: Fixed issue where initial values from query parameters were not respected in Search / Sort component's HTL.
 - 0388: Corrected spelling of Boolean in dialog value.
 - 0400: InternalRedirectRenditionDispatcherImpl now supports asset paths with spaces.
+- 0412: Search Results dialog not opening due to MetadataSchemaPropertiesImpl throws NPE when OSGi properties not configured
 
 ## [v1.7.0]
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/MetadataSchemaPropertiesImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/MetadataSchemaPropertiesImpl.java
@@ -87,27 +87,31 @@ public class MetadataSchemaPropertiesImpl implements MetadataProperties {
     }
 
     protected final Map<String, List<String>> collectExtraMetadataProperties(final Map<String, List<String>> collectedMetadata) {
-        for (final String entry : cfg.extra_metadata_properties()) {
-            final String propertyName = StringUtils.substringBefore(entry, "=");
-            final String fieldLabel = StringUtils.substringAfter(entry, "=");
-            collectMetadataProperty(fieldLabel, propertyName, collectedMetadata);
+        if (cfg != null && cfg.extra_metadata_properties() != null) {
+            for (final String entry : cfg.extra_metadata_properties()) {
+                final String propertyName = StringUtils.substringBefore(entry, "=");
+                final String fieldLabel = StringUtils.substringAfter(entry, "=");
+                collectMetadataProperty(fieldLabel, propertyName, collectedMetadata);
+            }
         }
 
         return collectedMetadata;
     }
 
     protected final Map<String, List<String>> removeBlacklistedMetadataProperties(final Map<String, List<String>> collectedMetadata) {
-        for (String propertyName : cfg.blacklisted_metadata_properties()) {
+        if (cfg != null && cfg.blacklisted_metadata_properties() != null) {
+            for (String propertyName : cfg.blacklisted_metadata_properties()) {
 
-            String withoutDotSlash = StringUtils.removeStart(propertyName, "./");
-            String withDotSlash = "./" + withoutDotSlash;
+                String withoutDotSlash = StringUtils.removeStart(propertyName, "./");
+                String withDotSlash = "./" + withoutDotSlash;
 
-            if (collectedMetadata.containsKey(withDotSlash)) {
-                collectedMetadata.remove(withDotSlash);
-            }
+                if (collectedMetadata.containsKey(withDotSlash)) {
+                    collectedMetadata.remove(withDotSlash);
+                }
 
-            if (collectedMetadata.containsKey(withoutDotSlash)) {
-                collectedMetadata.remove(withoutDotSlash);
+                if (collectedMetadata.containsKey(withoutDotSlash)) {
+                    collectedMetadata.remove(withoutDotSlash);
+                }
             }
         }
 


### PR DESCRIPTION
…iesImpl throws NPE when OSGi properties not configured

Per error log at https://github.com/Adobe-Marketing-Cloud/asset-share-commons/issues/412#issuecomment-500591139