### PR TITLE
#421 - AssetRenditions thumbnail sizes on AEM 6.3.x, and null input h…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 0388: Corrected spelling of Boolean in dialog value.
 - 0400: InternalRedirectRenditionDispatcherImpl now supports asset paths with spaces.
 - 0412: Search Results dialog not opening due to MetadataSchemaPropertiesImpl throws NPE when OSGi properties not configured
+- 0421: AssetRenditions thumbnail sizes on AEM 6.3.x, and null input handling in UrlUtil.
 
 ## [v1.7.0]
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/datasources/ComputedPropertiesDataSource.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/datasources/ComputedPropertiesDataSource.java
@@ -31,14 +31,10 @@ import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import java.io.IOException;
-import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -90,15 +86,15 @@ public class ComputedPropertiesDataSource extends SlingSafeMethodsServlet {
     }
 
     private boolean containsAny(String[] arrayOne, String[] arrayTwo) {
-    	if(arrayOne != null && arrayTwo != null) {
-    		for (final String valueOne : arrayOne) {
+        if (arrayOne != null && arrayTwo != null) {
+            for (final String valueOne : arrayOne) {
                 for (final String valueTwo : arrayTwo) {
                     if (StringUtils.equals(valueOne, valueTwo)) {
                         return true;
                     }
                 }
             }
-    	}
+        }
 
         return false;
     }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/UrlUtil.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/UrlUtil.java
@@ -29,19 +29,25 @@ public class UrlUtil {
      *
      * @param unescaped the unescaped URL representation to escape.
      *
-     * @return the escaped URL representation.
+     * @return the escaped URL representation, or null if the unescaped parameter is null.
      */
     public static final String escape(final String unescaped) {
-       return escape(unescaped, true);
+        if (unescaped == null) {
+            return null;
+        }
+
+        return escape(unescaped, true);
     }
 
     /**
      * @param unescaped the unescaped URL representation to escape.
      * @param preventDoubleEscaping true to check if unescaped is already escaped before attempting to re-escape.
-     * @return the escaped URL representation.
+     * @return the escaped URL representation, or null if the unescaped parameter is null.
      */
     public static final String escape(final String unescaped, final boolean preventDoubleEscaping) {
-        if (preventDoubleEscaping && isEscaped(unescaped)) {
+        if (unescaped == null) {
+            return null;
+        }  else if (preventDoubleEscaping && isEscaped(unescaped)) {
             return unescaped;
         }
 
@@ -57,8 +63,18 @@ public class UrlUtil {
     }
 
 
+    /**
+     * Checks if the candidate url appears to already be escaped.
+     * A null candidate parameter returns false;
+     *
+     * @param candidate the url to check if is already escaped.
+     * @return true if already escaped, else false. A null candidate also returns false.
+     */
     public static final boolean isEscaped(final String candidate) {
-        String unescaped = Text.unescape(candidate);
+        if (candidate == null) { return false; }
+
+        String unescaped = Text.unescape(StringUtils.stripToEmpty(candidate));
+
         unescaped = StringUtils.replace(unescaped, "/_jcr_content", "/jcr:content");
 
         if (!StringUtils.equals(unescaped, candidate)) {

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/util/UrlUtilTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/util/UrlUtilTest.java
@@ -19,50 +19,48 @@
 
 package com.adobe.aem.commons.assetshare.util;
 
-import org.junit.Before;
+import org.junit.Assert;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
 public class UrlUtilTest {
-
-    @Before
-    public void setUp() throws Exception {
-    }
 
     @Test
     public void escape_WithDoubleEscaping() {
         // allow double escaping
-        assertEquals("/content/dam/test.png", UrlUtil.escape("/content/dam/test.png", false));
-        assertEquals("/content/dam/test%20asset.png", UrlUtil.escape("/content/dam/test asset.png", false));
-        assertEquals("/content/dam/test%20asset.png/_jcr_content", UrlUtil.escape("/content/dam/test asset.png/jcr:content", false));
-        assertEquals("/content/dam/test%20folder/ir%c4%81%2bpu%20p%c3%b6%20%26p%c3%aep%e2%98%83.jpeg/_jcr_content/test",
+        Assert.assertNull(UrlUtil.escape(null, false));
+
+        Assert.assertEquals("/content/dam/test.png", UrlUtil.escape("/content/dam/test.png", false));
+        Assert.assertEquals("/content/dam/test%20asset.png", UrlUtil.escape("/content/dam/test asset.png", false));
+        Assert.assertEquals("/content/dam/test%20asset.png/_jcr_content", UrlUtil.escape("/content/dam/test asset.png/jcr:content", false));
+        Assert.assertEquals("/content/dam/test%20folder/ir%c4%81%2bpu%20p%c3%b6%20%26p%c3%aep%e2%98%83.jpeg/_jcr_content/test",
                 UrlUtil.escape("/content/dam/test folder/irā+pu pö &pîp☃.jpeg/jcr:content/test", false));
     }
-
-
 
     @Test
     public void escape_WithNoDoubleEscaping() {
         // No double escaping
-        assertEquals("/content/dam/test.png", UrlUtil.escape("/content/dam/test.png"));
-        assertEquals("/content/dam/test%20asset.png", UrlUtil.escape("/content/dam/test asset.png"));
-        assertEquals("/content/dam/test%20asset.png/_jcr_content", UrlUtil.escape("/content/dam/test asset.png/jcr:content"));
-        assertEquals("/content/dam/test%20folder/ir%c4%81%2bpu%20p%c3%b6%20%26p%c3%aep%e2%98%83.jpeg/_jcr_content/test",
+        Assert.assertNull(UrlUtil.escape(null));
+
+        Assert.assertEquals("/content/dam/test.png", UrlUtil.escape("/content/dam/test.png"));
+        Assert.assertEquals("/content/dam/test%20asset.png", UrlUtil.escape("/content/dam/test asset.png"));
+        Assert.assertEquals("/content/dam/test%20asset.png/_jcr_content", UrlUtil.escape("/content/dam/test asset.png/jcr:content"));
+        Assert.assertEquals("/content/dam/test%20folder/ir%c4%81%2bpu%20p%c3%b6%20%26p%c3%aep%e2%98%83.jpeg/_jcr_content/test",
                 UrlUtil.escape("/content/dam/test folder/irā+pu pö &pîp☃.jpeg/jcr:content/test"));
     }
 
     @Test
     public void isEscaped() {
-        assertTrue(UrlUtil.isEscaped("/content/dam/test.png"));
-        assertTrue(UrlUtil.isEscaped("/content/dam/test%20asset.png"));
-        assertTrue(UrlUtil.isEscaped("/content/dam/test%20asset.png/_jcr_content"));
-        assertTrue(UrlUtil.isEscaped("/content/dam/testasset.png/_jcr_content"));
-        assertTrue(UrlUtil.isEscaped("/content/dam/test%20folder/ir%c4%81%2bpu%20p%c3%b6%20%26p%c3%aep%e2%98%83.jpeg/_jcr_content/test"));
+        Assert.assertFalse(UrlUtil.isEscaped(null));
 
-        assertFalse(UrlUtil.isEscaped("/content/dam/test asset.png"));
-        assertFalse(UrlUtil.isEscaped("/content/dam/test asset.png/jcr:content"));
-        assertFalse(UrlUtil.isEscaped("/content/dam/testasset.png/jcr:content"));
-        assertFalse(UrlUtil.isEscaped("/content/dam/test folder/irā+pu pö &pîp☃.jpeg/jcr:content/test"));
+        Assert.assertTrue(UrlUtil.isEscaped("/content/dam/test.png"));
+        Assert.assertTrue(UrlUtil.isEscaped("/content/dam/test%20asset.png"));
+        Assert.assertTrue(UrlUtil.isEscaped("/content/dam/test%20asset.png/_jcr_content"));
+        Assert.assertTrue(UrlUtil.isEscaped("/content/dam/testasset.png/_jcr_content"));
+        Assert.assertTrue(UrlUtil.isEscaped("/content/dam/test%20folder/ir%c4%81%2bpu%20p%c3%b6%20%26p%c3%aep%e2%98%83.jpeg/_jcr_content/test"));
+
+        Assert.assertFalse(UrlUtil.isEscaped("/content/dam/test asset.png"));
+        Assert.assertFalse(UrlUtil.isEscaped("/content/dam/test asset.png/jcr:content"));
+        Assert.assertFalse(UrlUtil.isEscaped("/content/dam/testasset.png/jcr:content"));
+        Assert.assertFalse(UrlUtil.isEscaped("/content/dam/test folder/irā+pu pö &pîp☃.jpeg/jcr:content/test"));
     }
 }

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/config/com.adobe.aem.commons.assetshare.content.renditions.impl.dispatchers.InternalRedirectRenditionDispatcherImpl-SearchResults.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/config/com.adobe.aem.commons.assetshare.content.renditions.impl.dispatchers.InternalRedirectRenditionDispatcherImpl-SearchResults.xml
@@ -24,5 +24,5 @@
           label="Search Results"
           name="asset-share-commons-search-results"
           hidden="{Boolean}true"
-          rendition.mappings="[card=${asset.path}.thumb.300.300.jpg,list=${asset.path}.thumb.98.98.jpg]"
+          rendition.mappings="[card=${asset.path}.thumb.319.319.jpg,list=${asset.path}.thumb.140.140.jpg]"
 />


### PR DESCRIPTION
…andling in UrlUtil.

1. Updated the OOTB thumbnail servlet parameters to be:
   * card => <asset path>.thumb.319.319.jpg
   * list -> <asset path>.thumb.140.140.jpg

Since this simply invoked the OOTB Servlet, you can smoke-test what AEM is returning by just adding those selectors to an asset path, for example:

`http://localhost:4502/content/dam/asset-share-commons/en/public/pictures/lilly-rum-250927.jpg.thumb.300.300.jpg`

I have no idea why that (above) is returning a 140x93 image.. when the parameters are 300x300 (if i understand the "API" of the AEM thumbnail servlet correctly).

2. Might not have been clear in the PR for this, but the lack of "legacy mode" is expected for a NEW Image details component; The legacy toggle ONLY shows up if you have values already saved to the old legacy properties. This is to allow existing components to work, and be moved over, while requiring new uses to use the new mechanism.

3. Added a null check to UrlUtil. This was happening because the fallbackSrc property was blank (null). 

Open issue: Image component does not render at first.  .. im not sure what "does not render at first" means.