### PR TITLE
Feature/458 - Fixes Search Form submission in IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - 0430: Fixes issue with default search result layout is incorrect when Statistics component is added above the search results component.
 - 0443: Fixed issue on Search Page authoring where page-breaking errors are thrown if a Search Results component has not been added yet (Sort, Filter Toggle and Statistics).
+- 0458: Fixed issue with Form Submissions in IE11
 
 ## [v1.8.0]
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PagePredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PagePredicate.java
@@ -106,11 +106,4 @@ public interface PagePredicate extends Predicate {
      */
     @Deprecated
     Map<String, String> getParams(ParamTypes... excludeParamTypes);
-
-    /**
-     * @return the HTML form id
-     */
-    default String getFormId() {
-        return "asset-share-commons__form-id__1";
-    }
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PagePredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PagePredicate.java
@@ -107,4 +107,10 @@ public interface PagePredicate extends Predicate {
     @Deprecated
     Map<String, String> getParams(ParamTypes... excludeParamTypes);
 
+    /**
+     * @return the HTML form id
+     */
+    default String getFormId() {
+        return "asset-share-commons__form-id__1";
+    }
 }

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/form-data.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/form-data.js
@@ -21,11 +21,15 @@
 AssetShare.FormData = function (formEl) {
     "use strict";
 
-    var form = [];
+    var form = [],
+        formId = 'asset-share-commons__form-id__1';
 
     if (formEl) {
-        form = $(formEl).serializeArray();
+        formId = formEl.attr('id');
     }
+
+    // Select everything using the form attribute manually for IE11 support
+    form = $('[form="' + formId + '"]').serializeArray();
 
     /* IE polyfills for findIndex() and find() */
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/filter-toggle/filter-toggle.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/filter-toggle/filter-toggle.html
@@ -22,7 +22,7 @@
      data-sly-use.togglesTemplate="templates/toggles.html"
      data-sly-test.hideLabels="${properties['hideLabels']}"></sly>
 
-<div data-sly-test.ready="${pagePredicate != null}"
+<div data-sly-test.ready="${pagePredicate}"
         class="ui basic segment">
     <div class="ui column grid"
          data-sly-test.showApplyFilterToggle="${!properties['hideApplyFilterToggle']}">

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/templates/common.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/templates/common.html
@@ -19,22 +19,26 @@
 <template data-sly-template.data="${@ search, pagePredicate}">
     <span data-asset-share-id="results-data"
           data-asset-share-update-method="replace">
+
         <!--/* layout */-->
 
         <input type="hidden"
-                data-asset-share-id="layout"
-                name="layout"
-                value="${search.layout}"
-                data-asset-share-search-actions="all"/>
+               form="${pagePredicate.formId}"
+               data-asset-share-id="layout"
+               name="layout"
+               value="${search.layout}"
+               data-asset-share-search-actions="all"/>
 
         <!--/* p.offset */-->
 
         <input type="hidden"
+               form="${pagePredicate.formId}"
                name="p.offset"
                value="0"
                data-asset-share-search-actions="search,switch-layout,sort,deep-link"/>
 
         <input type="hidden"
+               form="${pagePredicate.formId}"
                name="p.offset"
                value="${search.results.nextOffset}"
                data-asset-share-search-actions="load-more"/>
@@ -42,6 +46,7 @@
         <!--/* p.limit */-->
 
         <input type="hidden"
+               form="${pagePredicate.formId}"
                name="p.limit"
                value="${search.results.runningTotal}"
                data-asset-share-search-actions="switch-layout,deep-link,sort"/>


### PR DESCRIPTION
Fix issues with IE11 form submission since IE11 does not seem to respect the form element's form attribute to group inputs outside a `<form>` tag.

All form elements for submission must have `<some-form-el form="asset-share-commons__form-id__1"/>`