### PR TITLE
479 - Align ASC to Maven Archetype 22 and AEM as a Cloud Service

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>1.9.1-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <artifactId>assetshare.core</artifactId>
     <name>asset-share-commons - Core</name>
-    <description>Core bundle for asset-share-commons</description>
+    <description>OSGi Core bundle for Asset Share Commons</description>
     <build>
         <plugins>
             <plugin>
@@ -198,6 +198,13 @@ Bundle-DocURL:
         <dependency>
             <groupId>com.adobe.acs</groupId>
             <artifactId>acs-aem-commons-bundle</artifactId>
+        </dependency>
+        <!-- JDK 11 -->
+        <!-- JDK 11 -->
+        <dependency>
+            <artifactId>org.apache.sling.javax.activation</artifactId>
+            <version>0.1.0</version>
+            <groupId>org.apache.sling</groupId>
         </dependency>
         <!-- Unit test dependencies -->
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,43 +28,6 @@
     <description>Core bundle for asset-share-commons</description>
     <build>
         <plugins>
-<!--
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                    <execution>
-                        <id>unpack</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.adobe.acs</groupId>
-                                    <artifactId>acs-aem-commons-bundle</artifactId>
-                                    <version>4.3.4</version>
-                                    <type>jar</type>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/classes</outputDirectory>
-                                    <includes>
-                                        com/adobe/acs/commons/util/ParameterUtil.class,
-                                        com/adobe/acs/commons/util/PathInfoUtil.class,
-                                        com/adobe/acs/commons/util/BufferedSlingHttpServletResponse.class,
-                                        com/adobe/acs/commons/util/ServletOutputStreamWrapper.class,
-                                        com/adobe/acs/commons/util/BufferedServletOutput.class,
-                                        com/adobe/acs/commons/util/BufferedServletResponse.class,
-                                        com/adobe/acs/commons/util/BufferedServletOutput$ResponseWriteMethod.class
-                                    </includes>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
--->
             <plugin>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>sling-maven-plugin</artifactId>
@@ -79,8 +42,6 @@
                             <goal>bnd-process</goal>
                         </goals>
                         <configuration>
-<!-- Embed-Dependency: acs-aem-commons-bundle;inline=com/adobe/acs/commons/util/ParameterUtil.class|com/adobe/acs/commons/util/PathInfoUtil.class|com/adobe/acs/commons/util/BufferedSlingHttpServletResponse.class|com/adobe/acs/commons/util/ServletOutputStreamWrapper.class|com/adobe/acs/commons/util/BufferedServletOutput.class|com/adobe/acs/commons/util/BufferedServletResponse.class|com/adobe/acs/commons/util/BufferedServletOutput$ResponseWriteMethod.class
- -->
                             <bnd><![CDATA[
 Bundle-Name: Asset Share Commons - Core
 Bundle-SymbolicName: com.adobe.aem.commons.assetshare.core

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>1.9.1-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>assetshare.core</artifactId>
@@ -28,7 +28,7 @@
     <description>Core bundle for asset-share-commons</description>
     <build>
         <plugins>
-
+<!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -64,7 +64,7 @@
                     </execution>
                 </executions>
             </plugin>
-
+-->
             <plugin>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>sling-maven-plugin</artifactId>
@@ -79,12 +79,14 @@
                             <goal>bnd-process</goal>
                         </goals>
                         <configuration>
+<!-- Embed-Dependency: acs-aem-commons-bundle;inline=com/adobe/acs/commons/util/ParameterUtil.class|com/adobe/acs/commons/util/PathInfoUtil.class|com/adobe/acs/commons/util/BufferedSlingHttpServletResponse.class|com/adobe/acs/commons/util/ServletOutputStreamWrapper.class|com/adobe/acs/commons/util/BufferedServletOutput.class|com/adobe/acs/commons/util/BufferedServletResponse.class|com/adobe/acs/commons/util/BufferedServletOutput$ResponseWriteMethod.class
+ -->
                             <bnd><![CDATA[
 Bundle-Name: Asset Share Commons - Core
 Bundle-SymbolicName: com.adobe.aem.commons.assetshare.core
 Bundle-Category: asset-share-commons
 Import-Package: javax.annotation;version=0.0.0,*
-Embed-Dependency: acs-aem-commons-bundle;inline=com/adobe/acs/commons/util/ParameterUtil.class|com/adobe/acs/commons/util/PathInfoUtil.class|com/adobe/acs/commons/util/BufferedSlingHttpServletResponse.class|com/adobe/acs/commons/util/ServletOutputStreamWrapper.class|com/adobe/acs/commons/util/BufferedServletOutput.class|com/adobe/acs/commons/util/BufferedServletResponse.class|com/adobe/acs/commons/util/BufferedServletOutput$ResponseWriteMethod.class
+-conditionalpackage: com.adobe.acs.commons.util.*,
 -exportcontents: ${packages;VERSIONED}
 -snapshot: ${tstamp;yyyyMMddHHmmssSSS}
 Bundle-DocURL:
@@ -192,10 +194,6 @@ Bundle-DocURL:
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>javax.activation</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <groupId>com.adobe.aem.commons</groupId>
     <artifactId>assetshare</artifactId>
     <packaging>pom</packaging>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <description>asset-share-commons</description>
 
     <modules>
@@ -720,13 +720,6 @@
                 <groupId>com.adobe.acs</groupId>
                 <artifactId>acs-aem-commons-bundle</artifactId>
                 <version>4.3.4</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- Java 11 Compile -->
-            <dependency>
-                <groupId>com.sun.activation</groupId>
-                <artifactId>javax.activation</artifactId>
-                <version>1.2.0</version>
                 <scope>compile</scope>
             </dependency>
             <!-- Testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -722,6 +722,13 @@
                 <version>4.3.4</version>
                 <scope>compile</scope>
             </dependency>
+            <!-- JDK 11 -->
+            <dependency>
+                <artifactId>org.apache.sling.javax.activation</artifactId>
+                <version>0.1.0</version>
+                <groupId>org.apache.sling</groupId>
+                <scope>provided</scope>
+            </dependency>
             <!-- Testing -->
             <dependency>
                 <groupId>org.junit</groupId>

--- a/release.properties
+++ b/release.properties
@@ -1,0 +1,13 @@
+#release configuration
+#Wed Jan 22 20:50:04 EST 2020
+projectVersionPolicyId=default
+scm.tagNameFormat=@{project.artifactId}-@{project.version}
+exec.additionalArguments=-P bintray,adobe-public,adobe-private
+remoteTagging=true
+scm.commentPrefix=[maven-scm] \:
+pushChanges=true
+completedPhase=check-poms
+scm.url=scm\:git\:https\://github.com/Adobe-Marketing-Cloud/asset-share-commons.git
+exec.snapshotReleasePluginAllowed=false
+scm.id=adobe-acsbuild-github-token
+preparationGoals=clean install

--- a/repository-structure/pom.xml
+++ b/repository-structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>1.9.1-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>1.9.1-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.content.sample/pom.xml
+++ b/ui.content.sample/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>1.9.1-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>1.9.1-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Fixing issues described in https://github.com/Adobe-Marketing-Cloud/asset-share-commons/pull/486

resulting in:
![image](https://user-images.githubusercontent.com/1451868/72950547-b964dc00-3d59-11ea-94b8-a698cc234e59.png)
