### PR TITLE
#497 - Fixed POMs to run Unit Tests and re-introduce ASC specific pro…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -200,7 +200,6 @@ Bundle-DocURL:
             <artifactId>acs-aem-commons-bundle</artifactId>
         </dependency>
         <!-- JDK 11 -->
-        <!-- JDK 11 -->
         <dependency>
             <artifactId>org.apache.sling.javax.activation</artifactId>
             <version>0.1.0</version>
@@ -210,30 +209,22 @@ Bundle-DocURL:
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit-addons</groupId>
             <artifactId>junit-addons</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.wcm</groupId>
-            <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
         </dependency>
         <dependency>
             <groupId>io.wcm</groupId>
@@ -242,6 +233,18 @@ Bundle-DocURL:
         <dependency>
             <groupId>uk.org.lidalia</groupId>
             <artifactId>slf4j-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.converter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PropertyValuesPredicateEvaluator.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PropertyValuesPredicateEvaluator.java
@@ -33,8 +33,6 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.jcr.query.Row;
 import java.util.*;
@@ -47,14 +45,14 @@ import static java.util.Collections.emptyList;
 /**
  * The QueryBuilder predicate for this Sample would be structured like so...
  * <p>
- * type=cq:PageContent
- * path=/content
+ * type=cq:PageContent<br>
+ * path=/content<br>
  * <p>
- * propertyvalues.values=val1,val2
- * propertyvalues.delimiter=,
- * propertyvalues.XXX <- all other JcrPropertyPredicateEvaluator configs
+ * propertyvalues.values=val1,val2<br>
+ * propertyvalues.delimiter=,<br>
+ * propertyvalues.XXX &lt;- all other JcrPropertyPredicateEvaluator configs<br>
  * <p>
- * `values` is the list of values to break out into OOTB property.#_property=value[#]
+ * `values` is the list of values to break out into OOTB property.#_property=value[#]<br>
  * `delimiter` is the delimiter which is used to split the values string
  */
 @Component(
@@ -64,8 +62,6 @@ import static java.util.Collections.emptyList;
         ocd = PropertyValuesPredicateEvaluator.Cfg.class
 )
 public class PropertyValuesPredicateEvaluator implements PredicateEvaluator {
-    private static final Logger log = LoggerFactory.getLogger(PropertyValuesPredicateEvaluator.class);
-
     private PredicateEvaluator propertyEvaluator = new JcrPropertyPredicateEvaluator();
     private PredicateEvaluator fulltextEvaluator = new FulltextPredicateEvaluator();
 

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/components/details/impl/EditorLinksImplTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/components/details/impl/EditorLinksImplTest.java
@@ -20,14 +20,12 @@
 package com.adobe.aem.commons.assetshare.components.details.impl;
 
 import com.adobe.aem.commons.assetshare.components.details.EditorLinks;
-import com.adobe.aem.commons.assetshare.components.details.Metadata;
 import com.adobe.aem.commons.assetshare.content.AssetResolver;
 import com.adobe.aem.commons.assetshare.content.impl.AssetModelImpl;
 import com.adobe.aem.commons.assetshare.content.impl.AssetResolverImpl;
 import com.adobe.aem.commons.assetshare.content.properties.ComputedProperties;
 import com.adobe.aem.commons.assetshare.content.properties.impl.ComputedPropertiesImpl;
 import io.wcm.testing.mock.aem.junit.AemContext;
-import org.apache.sling.settings.SlingSettingsService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PredicateEvaluatorUtilTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PredicateEvaluatorUtilTest.java
@@ -1,10 +1,9 @@
 package com.adobe.aem.commons.assetshare.search.impl.predicateevaluators;
 
 import com.day.cq.search.Predicate;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.List;
 

--- a/pom.xml
+++ b/pom.xml
@@ -439,52 +439,6 @@
     </build>
 
     <profiles>
-        <!-- ====================================================== -->
-        <!-- A D O B E P U B L I C P R O F I L E -->
-        <!-- ====================================================== -->
-        <profile>
-            <id>adobe-public</id>
-
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-
-            <properties>
-                <releaseRepository-Id>adobe-public-releases</releaseRepository-Id>
-                <releaseRepository-Name>Adobe Public Releases</releaseRepository-Name>
-                <releaseRepository-URL>https://repo.adobe.com/nexus/content/groups/public</releaseRepository-URL>
-            </properties>
-
-            <repositories>
-                <repository>
-                    <id>adobe-public-releases</id>
-                    <name>Adobe Public Repository</name>
-                    <url>https://repo.adobe.com/nexus/content/groups/public</url>
-                    <releases>
-                        <enabled>true</enabled>
-                        <updatePolicy>never</updatePolicy>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>adobe-public-releases</id>
-                    <name>Adobe Public Repository</name>
-                    <url>https://repo.adobe.com/nexus/content/groups/public</url>
-                    <releases>
-                        <enabled>true</enabled>
-                        <updatePolicy>never</updatePolicy>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
 
         <!-- Development profile: install only the bundle -->
         <profile>
@@ -1013,5 +967,36 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <!-- Adone Maven Repository -->
+    <repositories>
+        <repository>
+            <id>adobe-public-releases</id>
+            <name>Adobe Public Repository</name>
+            <url>https://repo.adobe.com/nexus/content/groups/public</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>adobe-public-releases</id>
+            <name>Adobe Public Repository</name>
+            <url>https://repo.adobe.com/nexus/content/groups/public</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
                     </dependencies>
                     <configuration>
                         <parallel>methods</parallel>
-                        <threadCount>1</threadCount>
+                        <threadCount>5</threadCount>
                     </configuration>
                 </plugin>
                 <!-- Maven Failsafe Plugin -->
@@ -357,8 +357,10 @@
                 <!-- Maven Javadoc Plugin -->
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9.1</version>
+                    <version>3.1.1</version>
                     <configuration>
+                        <encoding>${project.build.sourceEncoding}</encoding>
+                        <source>8</source>
                         <excludePackageNames>
                             *.impl
                         </excludePackageNames>
@@ -401,7 +403,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.0.5</version>
                 </plugin>
                 <!-- Maven Checkstyle Plugin -->
                 <plugin>
@@ -566,9 +568,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <encoding>${project.build.sourceEncoding}</encoding>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -921,7 +921,8 @@
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
-                <version>2.4.14</version>
+                <!-- Bumping this to 2.4.14 changes behavior in how mock context resolves ranked service, which breaks ComputedPropertiesTest -->
+                <version>2.4.10</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,13 +68,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.0-r1585899</version>
                 <configuration>
                     <scmCommentPrefix>[maven-scm] :</scmCommentPrefix>
                     <preparationGoals>clean install</preparationGoals>
                     <goals>install</goals>
                     <releaseProfiles>release</releaseProfiles>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <projectVersionPolicyId>OddEvenVersionPolicy</projectVersionPolicyId>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.release</groupId>
+                        <artifactId>maven-release-oddeven-policy</artifactId>
+                        <version>3.0-r1585899</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <!-- Maven Source Plugin -->
             <plugin>
@@ -188,9 +197,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.1</version>
+                    <version>2.21.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-junit47</artifactId>
+                            <version>2.21.0</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
-                        <useSystemClassLoader>false</useSystemClassLoader>
+                        <parallel>methods</parallel>
+                        <threadCount>1</threadCount>
                     </configuration>
                 </plugin>
                 <!-- Maven Failsafe Plugin -->
@@ -337,6 +354,86 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
+                <!-- Maven Javadoc Plugin -->
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.9.1</version>
+                    <configuration>
+                        <excludePackageNames>
+                            *.impl
+                        </excludePackageNames>
+                    </configuration>
+                </plugin>
+                <!-- Maven Jacoco Plugin -->
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.4</version>
+                    <executions>
+                        <execution>
+                            <id>default-prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <!-- Maven PMD Plugin -->
+                <plugin>
+                    <artifactId>maven-pmd-plugin</artifactId>
+                    <version>3.2</version>
+                    <configuration>
+                        <linkXRef>false</linkXRef>
+                        <rulesets>
+                            <ruleset>acs/pmd/rules.xml</ruleset>
+                        </rulesets>
+                        <targetJdk>1.8</targetJdk>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.adobe.acs</groupId>
+                            <artifactId>coding-standards</artifactId>
+                            <version>0.0.1</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <!-- Maven Findbugs Plugin -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>findbugs-maven-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <!-- Maven Checkstyle Plugin -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>2.12.1</version>
+                    <configuration>
+                        <linkXRef>false</linkXRef>
+                        <configLocation>acs/checkstyle/checks.xml</configLocation>
+                        <includeResources>false</includeResources>
+                        <includeTestResources>false</includeTestResources>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.adobe.acs</groupId>
+                            <artifactId>checkstyle-osgi-checks</artifactId>
+                            <version>0.0.3</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.adobe.acs</groupId>
+                            <artifactId>coding-standards</artifactId>
+                            <version>0.0.1</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <!-- Maven JSLint Plugin -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>jslint-maven-plugin</artifactId>
+                    <version>1.0.1</version>
+                </plugin>
+                <!-- -->
             </plugins>
         </pluginManagement>
     </build>
@@ -548,11 +645,125 @@
                     <url>https://api.bintray.com/maven/${bintray.org}/${bintray.repo}/${bintray.package}/;publish=1</url>
                 </snapshotRepository>
             </distributionManagement>
-
         </profile>
 
+        <profile>
+            <id>analysis</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>pmd</goal>
+                                    <goal>cpd</goal>
+                                    <!-- build will fail on warnings -->
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>javadoc</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>checkstyle</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>analysisCI</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>pmd</goal>
+                                    <goal>cpd</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>javadoc</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>findbugs</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>checkstyle</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>autoInstallPackage-all</id>
+            <modules>
+                <module>core</module>
+                <module>ui.apps</module>
+                <module>ui.content</module>
+            </modules>
+        </profile>
     </profiles>
-
 
     <!-- ====================================================================== -->
     <!-- D E P E N D E N C I E S -->
@@ -731,16 +942,15 @@
             </dependency>
             <!-- Testing -->
             <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>5.4.1</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>junit-addons</groupId>
+                <artifactId>junit-addons</artifactId>
+                <version>1.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -756,21 +966,16 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-junit-jupiter</artifactId>
-                <version>3.2.4</version>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
+                <version>2.4.14</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>junit-addons</groupId>
-                <artifactId>junit-addons</artifactId>
-                <version>1.4</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.wcm</groupId>
-                <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
-                <version>2.7.2</version>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
+                <!-- Bumping this to 2.4.0 changes behavior in how servlet.service(..) is processed, which breaks all servlet tests -->
+                <version>2.3.10</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -783,6 +988,27 @@
                 <groupId>uk.org.lidalia</groupId>
                 <artifactId>slf4j-test</artifactId>
                 <version>1.0.1</version>
+                <scope>test</scope>
+            </dependency>
+            <!-- Require to resolve ServiceTracker in tests; else they fail -->
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.util.tracker</artifactId>
+                <version>1.5.2</version>
+                <scope>test</scope>
+            </dependency>
+            <!-- Require to resolve OSGi Tacker Classes in tests; else they fail -->
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.util.converter</artifactId>
+                <version>1.0.1</version>
+                <scope>test</scope>
+            </dependency>
+            <!-- Require to resolve ObjectConverter in tests; else they fail -->
+            <dependency>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.api</artifactId>
+                <version>2.22.0</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
…files

* Drops JUnit back to Junit4 (since all our tests are in JUnit4)
   * Tried to get JUnit5 + Vintage, but ran this broke (though, now in hindsight, it may be due to other issues I had to resolve)
   * We can try re-introducing this after the build stabilized and tests work. 
* Re-added a number of missing ASC profiles/plugins to reactor POM that were not moved over during the Maven Archetype 22 refactor.

No changelog as this fixee an unreleased bug.