### PR TITLE
Fix js errors when the top frame doesn't have the same origin

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js.txt
@@ -10,3 +10,4 @@ form-data.js
 ajax.js
 contexthub.js
 events.js
+util.js

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/navigation.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/navigation.js
@@ -24,8 +24,16 @@ AssetShare.Navigation = (function ($, window, ns) {
     var LOCAL_STORAGE_KEY = "asset-share-commons";
 
     function setAddressBar(url) {
-        if (window.top.history && window.top.history.pushState) {
+        var hasHistoryPush = window.history && typeof window.history.pushState === "function";
+
+        if (!hasHistoryPush) {
+            return;
+        }
+
+        if (ns.Util.isSameOrigin()) {
             window.top.history.pushState({}, window.top.document.title, url);
+        } else {
+            window.history.pushState({}, window.document.title, url);
         }
     }
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/search/search.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/search/search.js
@@ -43,7 +43,12 @@ AssetShare.Search = (function (window, $, ns, ajax) {
     }
 
     function setAddressBar(queyParams) {
-        ns.Navigation.addressBar(window.top.location.pathname + "?" + queyParams);
+        if (ns.Util.isSameOrigin()) {
+            ns.Navigation.addressBar(window.top.location.pathname + "?" + queyParams);
+        } else {
+            ns.Navigation.addressBar(window.location.pathname + "?" + queyParams);
+        }
+
         ns.Navigation.returnUrl(window.location.pathname + "?" + queyParams);
     }
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/util.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/util.js
@@ -1,0 +1,43 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright [2017]  Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*global jQuery: false, AssetShare: false */
+AssetShare.Util = (function() {
+    "use strict";
+
+    function isIframe() {
+      return window.top.location !== window.location;
+    }
+  
+    function isSameOrigin() {
+      if (!isIframe()) {
+        return true;
+      }
+  
+      try {
+        var __ = window.top.location;
+      } catch (e) {
+        if (e instanceof window.DOMException) {
+          return e.code !== e.SECURITY_ERR;
+        }
+        return true;
+      }
+    }
+  
+    return { isIframe: isIframe, isSameOrigin: isSameOrigin };
+})();


### PR DESCRIPTION
When ASC is used inside an iframe that doesn't have the same origin with the top (parent) frame, there are js security exceptions thrown.

This PR addresses these issues by checking wether the AEM frame has the same origin with the top frame. If it does, it doesn't alter the current behaviour. Otherwise only the iframe's URL is modified.