### PR TITLE
Extended the configuration to allow download/share only via the cart.

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/Config.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/Config.java
@@ -106,9 +106,14 @@ public interface Config {
     boolean isCartEnabled();
 
     /**
-     * @return true if the download action is enabled.
+     * @return true if the download action is enabled for asset card and asset details page.
      */
     boolean isDownloadEnabled();
+
+    /**
+     * @return true if the download action is enabled in the cart.
+     */
+    boolean isDownloadEnabledCart();
 
     /**
      * @return true if the license action is enabled.
@@ -116,9 +121,14 @@ public interface Config {
     boolean isLicenseEnabled();
 
     /**
-     * @return true if the share action is enabled.
+     * @return true if the share action is enabled for asset card and asset details page.
      */
     boolean isShareEnabled();
+
+    /**
+     * @return true if the share action is enabled in the cart.
+     */
+    boolean isShareEnabledCart();
 
     /**
      * @deprecated We no longer detect Dynamic Media; Return false always.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/ConfigImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/ConfigImpl.java
@@ -190,12 +190,42 @@ public class ConfigImpl implements Config {
 
     @Override
     public boolean isShareEnabled() {
-        return shareService != null && properties.get(PN_SHARE_ENABLED, false);
+        return shareService != null && compareEnablementValue(properties, PN_SHARE_ENABLED, ActionEnablements.ALWAYS);
     }
 
     @Override
     public boolean isDownloadEnabled() {
-        return properties.get(PN_DOWNLOAD_ENABLED, false);
+        return compareEnablementValue(properties, PN_DOWNLOAD_ENABLED, ActionEnablements.ALWAYS);
+    }
+
+    @Override
+    public boolean isDownloadEnabledCart() {
+        if(isCartEnabled()) {
+            return compareEnablementValue(properties, PN_DOWNLOAD_ENABLED, ActionEnablements.ALWAYS, ActionEnablements.CART);
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean isShareEnabledCart() {
+        if(isCartEnabled() && shareService != null) {
+            return compareEnablementValue(properties, PN_SHARE_ENABLED, ActionEnablements.ALWAYS, ActionEnablements.CART);
+        }
+
+        return false;
+    }
+
+    private boolean compareEnablementValue(ValueMap properties, String propertyName, ActionEnablements... validValues) {
+        String strValue = properties.get(propertyName, ActionEnablements.NEVER.value);
+        ActionEnablements enablementVal = ActionEnablements.forValue(strValue);
+        for(ActionEnablements enablement : validValues) {
+            if(enablement == enablementVal) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Override
@@ -265,5 +295,27 @@ public class ConfigImpl implements Config {
         }
 
         return "/";
+    }
+
+    private enum ActionEnablements {
+        ALWAYS("true"),
+        NEVER("false"),
+        CART("cart");
+
+        private String value;
+
+        ActionEnablements(String value) {
+            this.value=value;
+        }
+
+        public static ActionEnablements forValue(String value) {
+            for(ActionEnablements enablement : ActionEnablements.values()) {
+                if(enablement.value.equalsIgnoreCase(value)) {
+                    return enablement;
+                }
+            }
+
+            return ActionEnablements.NEVER;
+        }
     }
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("1.3.0")
+@Version("1.4.0")
 package com.adobe.aem.commons.assetshare.configuration;
 
 import org.osgi.annotation.versioning.Version;

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/cart.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/cart.html
@@ -92,11 +92,11 @@
         </div>
         <div class="ui primary right labeled icon button"
         	 data-asset-share-id="share-all"
-             data-sly-test="${config.shareEnabled && cart.assets.size > 0}">
+             data-sly-test="${config.shareEnabledCart && cart.assets.size > 0}">
             ${properties['shareButton']}
              <i class="send icon"></i>
         </div>
-        <button data-sly-test="${config.downloadEnabled && cart.assets.size > 0}"
+        <button data-sly-test="${config.downloadEnabledCart && cart.assets.size > 0}"
         	    data-asset-share-id="download-all"
                 type="submit"
                 class="ui postive primary right labeled icon button">

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/page/init.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/page/init.html
@@ -21,11 +21,11 @@
 
 <!--/* These params MUST be loaded before the dependent Asset Share Commons JavaScripts (ie. Modals) */-->
 <input type="hidden"
-       data-sly-test="${config.shareEnabled}"
+       data-sly-test="${config.shareEnabled || config.shareEnabledCart}"
        data-asset-share-id="share-url"
        value="${config.shareActionUrl}"/>
 <input type="hidden"
-       data-sly-test="${config.downloadEnabled}"
+       data-sly-test="${config.downloadEnabled || config.downloadEnabledCart}"
        data-asset-share-id="download-url"
        value="${config.downloadActionUrl}"/>
 <input type="hidden"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/search-page/_cq_dialog/asset-share-commons/actions/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/search-page/_cq_dialog/asset-share-commons/actions/.content.xml
@@ -35,11 +35,24 @@
                     <items jcr:primaryType="nt:unstructured">
                         <download-enabled
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                 name="./config/actions/download/enabled"
-                                value="true"
-                                uncheckedValue="false"
-                                text="Enable Downloading"/>
+                                fieldLabel="Enable Downloading">
+                            <items jcr:primaryType="nt:unstructured">
+                                <always
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Always"
+                                        value="true"/>
+                                <never
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Never"
+                                        value="false"/>
+                                <cart
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Cart Only"
+                                        value="cart"/>
+                            </items>
+                        </download-enabled>
                         <download
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
@@ -63,11 +76,24 @@
                                 rootPath="/content"/>
                         <share-enabled
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                 name="./config/actions/share/enabled"
-                                value="true"
-                                uncheckedValue="false"
-                                text="Enable Sharing"/>
+                                fieldLabel="Enable Sharing">
+                            <items jcr:primaryType="nt:unstructured">
+                                <always
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Always"
+                                        value="true"/>
+                                <never
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Never"
+                                        value="false"/>
+                                <cart
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Cart Only"
+                                        value="cart"/>
+                            </items>
+                        </share-enabled>
                         <share
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"


### PR DESCRIPTION
Draft PR for #550 

In some prelim testing it seems to work well, but likely needs a bit more testing before it can be merged. I used true/false for the values to maintain backwards compatibility while also extending to have "cart" as an option to enable those actions only for the cart.