### PR TITLE
Modifying the logic of the MessagesImpl.isMessageEmpty method

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/MessagesImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/MessagesImpl.java
@@ -43,7 +43,6 @@ import java.util.List;
 public class MessagesImpl implements Messages {
     private static final String MESSAGES_REL_PATH = ConfigImpl.NODE_NAME + "/messages";
     private static final String PN_MESSAGE_STYLE = "style";
-    private static final String PN_MESSAGE_LABEL = "label";
     private static final String PN_MESSAGE_TEXT = "text";
     private static final String PN_MESSAGE_EVENT_ID = "eventId";
 
@@ -95,9 +94,8 @@ public class MessagesImpl implements Messages {
     }
 
     private boolean isMessageEmpty(ValueMap properties) {
-        return StringUtils.isBlank(properties.get(PN_MESSAGE_STYLE, String.class)) &&
-                StringUtils.isBlank(properties.get(PN_MESSAGE_LABEL, String.class)) &&
-                StringUtils.isBlank(properties.get(PN_MESSAGE_TEXT, String.class)) &&
+        return StringUtils.isBlank(properties.get(PN_MESSAGE_STYLE, String.class)) ||
+                StringUtils.isBlank(properties.get(PN_MESSAGE_TEXT, String.class)) ||
                 StringUtils.isBlank(properties.get(PN_MESSAGE_EVENT_ID, String.class));
     }
 


### PR DESCRIPTION
- If the text value in the dialog for a message is not set, the message
  banner will still show with an empty message
- The logic for isMessageEmpty will currently never return false because
  the message fieldsets contain a hidden field equal to the event id
- The message style does not allow for an empty input in the dropdown
  options and if an empty value is passed to the component it will not
  render the message properly.
- There is a property `label` that is used in the method that I cannot
  find used in any other place at any other given time in the commit
  history.
- I have removed the propety logic referencing `label` as it is not used
  in anything I can see in the reference implementation and it makes the
  isBlank check more difficult since well - in the reference its always
  empty.
- I have modified the blank logic to be ors instead of ands for the 3
  remaining properties - text, event id, and style since all 3 of these
  are the driving pieces of the functionality for the messages logic.
- If there is something I am missing WRT the `label` property this
  change will affect that logic.