### PR TITLE
removing core component embed

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -61,6 +61,11 @@
                         </embedded>
                         <embedded>
                             <groupId>com.adobe.aem.commons</groupId>
+                            <artifactId>assetshare.core</artifactId>
+                            <target>/apps/asset-share-commons-packages/application/install</target>
+                        </embedded>
+                        <embedded>
+                            <groupId>com.adobe.aem.commons</groupId>
                             <artifactId>assetshare.ui.content</artifactId>
                             <type>zip</type>
                             <target>/apps/asset-share-commons-packages/content/install</target>
@@ -72,16 +77,9 @@
                             <target>/apps/asset-share-commons-packages/content/install</target>
                         </embedded>
                         <embedded>
-                            <groupId>com.adobe.cq</groupId>
-                            <artifactId>core.wcm.components.content</artifactId>
-                            <type>zip</type>
-                            <target>/apps/asset-share-commons-vendor-packages/application/install</target>
-                        </embedded>
-                        <embedded>
-                            <groupId>com.adobe.cq</groupId>
-                            <artifactId>core.wcm.components.config</artifactId>
-                            <type>zip</type>
-                            <target>/apps/asset-share-commons-vendor-packages/content/install</target>
+                            <groupId>com.adobe.aem.commons</groupId>
+                            <artifactId>assetshare.core</artifactId>
+                            <target>/apps/asset-share-commons-packages/application/install</target>
                         </embedded>
                     </embeddeds>
                     <allowIndexDefinitions>true</allowIndexDefinitions>
@@ -190,16 +188,6 @@
             <groupId>com.adobe.aem.commons</groupId>
             <artifactId>assetshare.ui.content.sample</artifactId>
             <version>${project.version}</version>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>com.adobe.cq</groupId>
-            <artifactId>core.wcm.components.content</artifactId>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>com.adobe.cq</groupId>
-            <artifactId>core.wcm.components.config</artifactId>
             <type>zip</type>
         </dependency>
     </dependencies>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -76,11 +76,6 @@
                             <type>zip</type>
                             <target>/apps/asset-share-commons-packages/content/install</target>
                         </embedded>
-                        <embedded>
-                            <groupId>com.adobe.aem.commons</groupId>
-                            <artifactId>assetshare.core</artifactId>
-                            <target>/apps/asset-share-commons-packages/application/install</target>
-                        </embedded>
                     </embeddeds>
                     <allowIndexDefinitions>true</allowIndexDefinitions>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <vault.user>admin</vault.user>
         <vault.password>admin</vault.password>
         <package.group>asset-share-commons</package.group>
-        <core.wcm.components.version>2.8.0</core.wcm.components.version>
+        <core.wcm.components.version>2.14.0</core.wcm.components.version>
         <frontend-maven-plugin.version>1.9.0</frontend-maven-plugin.version>
         <node.version>v13.7.0</node.version>
         <npm.version>6.13.1</npm.version>
@@ -804,18 +804,7 @@
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.core</artifactId>
                 <version>${core.wcm.components.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.adobe.cq</groupId>
-                <artifactId>core.wcm.components.content</artifactId>
-                <type>zip</type>
-                <version>${core.wcm.components.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.adobe.cq</groupId>
-                <artifactId>core.wcm.components.config</artifactId>
-                <type>zip</type>
-                <version>${core.wcm.components.version}</version>
+                <scope>provided</scope>
             </dependency>
             <!-- Apache Sling Dependencies -->
             <dependency>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -63,28 +63,6 @@
                             <artifactId>ui.apps.structure</artifactId>
                         </repositoryStructurePackage>
                     </repositoryStructurePackages>
-                    <embeddeds>
-                        <embedded>
-                            <groupId>com.adobe.cq</groupId>
-                            <artifactId>core.wcm.components.core</artifactId>
-                            <target>/apps/asset-share-commons/install</target>
-                        </embedded>
-                        <embedded>
-                            <groupId>com.adobe.aem.commons</groupId>
-                            <artifactId>assetshare.core</artifactId>
-                            <target>/apps/asset-share-commons/install</target>
-                        </embedded>
-                    </embeddeds>
-                    <dependencies>
-                        <dependency>
-                            <groupId>com.adobe.cq</groupId>
-                            <artifactId>core.wcm.components.content</artifactId>
-                        </dependency>
-                        <dependency>
-                            <groupId>com.adobe.cq</groupId>
-                            <artifactId>core.wcm.components.config</artifactId>
-                        </dependency>
-                    </dependencies>
                 </configuration>
             </plugin>
             <plugin>
@@ -129,20 +107,6 @@
             <groupId>com.adobe.aem.commons</groupId>
             <artifactId>assetshare.ui.frontend.theme.dark</artifactId>
             <version>${project.version}</version>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>com.adobe.cq</groupId>
-            <artifactId>core.wcm.components.core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.adobe.cq</groupId>
-            <artifactId>core.wcm.components.content</artifactId>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>com.adobe.cq</groupId>
-            <artifactId>core.wcm.components.config</artifactId>
             <type>zip</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Ups the Core Component dependency version to 2.14.0 (can move to 2.15.0 once its available in the Cloud)
- Removes the Core Component Embed from the `all` module
- Moves the Asset Share Commons Core module embed into the `all` module

Affect on implementations:
- For Cloud Service implementations Core Components are automatically available, no effect
- For 6.5,6.4 customer implementations will be responsible for also embedding a compatible version of Core Components in their own project (in addition to Asset Share Commons dependencies)