### PR TITLE
Feature/578b - ASC All package depends on Core Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - 0504: Added RequireAem OSGi Service to determine if ASC is running in the Adobe Cloud or not.
 - 0511: Aligned Download Action with Asset Renditions framework in a plug-able manner.
- 
+- 0578: Make Asset Share Commons all package depend on Core Components
+
 ### Changed
 
 - 0317: Re-organized Semantic UI theme to be served from a dedicated front-end module; Updated vendor dependencies to latest versions; Optimized client-side library dependency chain

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -82,6 +82,14 @@
                         </embedded>
                     </embeddeds>
                     <allowIndexDefinitions>true</allowIndexDefinitions>
+                    <dependencies>
+                        <!-- Require AEM WCM Core Components to be installed on AEM
+                             Asset Share Commons will not auto-install Core Components for you -->
+                        <dependency>
+                            <groupId>com.adobe.cq</groupId>
+                            <artifactId>core.wcm.components.content</artifactId>
+                        </dependency>
+                    </dependencies>
                 </configuration>
             </plugin>
             <plugin>
@@ -187,6 +195,12 @@
             <groupId>com.adobe.aem.commons</groupId>
             <artifactId>assetshare.ui.content.sample</artifactId>
             <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.cq</groupId>
+            <artifactId>core.wcm.components.content</artifactId>
+            <version>${core.wcm.components.version}</version>
             <type>zip</type>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -738,6 +738,13 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>com.adobe.cq</groupId>
+                <artifactId>core.wcm.components.content</artifactId>
+                <version>${core.wcm.components.version}</version>
+                <type>zip</type>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>3.0.2</version>
@@ -832,7 +839,7 @@
         </dependencies>
     </dependencyManagement>
 
-    <!-- Adone Maven Repository -->
+    <!-- Adobe Maven Repository -->
     <repositories>
         <repository>
             <id>adobe-public-releases</id>


### PR DESCRIPTION
ASC should not be installable if Core Components are not present on AEM. This adds a package dependency on ASC all package on immutable Core Components package(currently at v2.14.0). 

(You cannot package depend on a container package, thus we pick the immtuable package)