### PR TITLE
Removed the class "outline" for the semantic ui icon "close"

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/user-menu.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/user-menu.html
@@ -47,7 +47,7 @@
                     <!--/* Toggle Close Rail  */-->
                     <a class="item cmp-siderail__toggle"
                        data-asset-share-commons-toggle="true">
-                        <i class="big close outline icon"></i>
+                        <i class="big close icon"></i>
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
Issue:
Hamburger menu's close icon is not loading

![image](https://user-images.githubusercontent.com/34283439/111303481-980c3100-867a-11eb-88b9-10d0ea93b720.png)

Fix:
I don't see a semantic ui icon class by name "close outline". Hence, updated user-menu.html by removing the usage of class "outline"
![image](https://user-images.githubusercontent.com/34283439/111304375-a9097200-867b-11eb-9d88-4660760a0b89.png)

