### PR TITLE
Direct download

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/ConfigImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/ConfigImpl.java
@@ -72,6 +72,8 @@ public class ConfigImpl implements Config {
     private static final String PN_DOWNLOAD_ENABLED = "config/actions/download/enabled";
     private static final String PN_DOWNLOAD_VIEW_PATH = "config/actions/download/path";
 
+    private static final String PN_DOWNLOADS_VIEW_PATH = "config/actions/downloads/path";
+
     private static final String PN_CART_ENABLED = "config/actions/cart/enabled";
     private static final String PN_CART_VIEW_PATH = "config/actions/cart/path";
 
@@ -175,7 +177,7 @@ public class ConfigImpl implements Config {
 
     @Override
     public String getDownloadsActionUrl() {
-        return properties.get(PN_DOWNLOAD_VIEW_PATH, rootPath + "/actions/downloads") + "." + viewSelector + HTML_EXTENSION;
+        return properties.get(PN_DOWNLOADS_VIEW_PATH, rootPath + "/actions/downloads") + "." + viewSelector + HTML_EXTENSION;
     }
 
     @Override

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/async/impl/AsyncAssetRenditionsDownloadServlet.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/async/impl/AsyncAssetRenditionsDownloadServlet.java
@@ -49,7 +49,6 @@ import static com.adobe.aem.commons.assetshare.content.renditions.download.async
         property = {
                 "sling.servlet.methods=POST",
                 "sling.servlet.resourceTypes=asset-share-commons/actions/download",
-                "sling.servlet.resourceTypes=asset-share-commons/actions/share",
                 "sling.servlet.selectors=download-asset-renditions",
                 "sling.servlet.extensions=zip"
         }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/async/impl/AsyncAssetRenditionsDownloadServlet.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/async/impl/AsyncAssetRenditionsDownloadServlet.java
@@ -65,7 +65,7 @@ public class AsyncAssetRenditionsDownloadServlet extends SlingAllMethodsServlet 
     private static final String REQ_KEY_RENDITION_NAMES = "renditionName";
 
     private static final String PN_ALLOWED_RENDITION_NAMES = "allowedRenditionNames";
-    private static final String PN_BASE_ARCHIVE_NAME = "zipFileName";
+    private static final String PN_BASE_ARCHIVE_NAME = "fileName";
 
     public static final String PARAM_ARCHIVE_NAME = "archiveName";
     private static final String DOWNLOAD_ARCHIVE_NAME = PARAM_ARCHIVE_NAME;

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/modal.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/modal.js
@@ -84,7 +84,6 @@ AssetShare.SemanticUI.Modal = (function ($, ns) {
             // No more modals left to load!
             return;
         }
-        
         $.post(modal.url, modal.data, function (htmlResponse) {
             modal.options = modal.options || {};
             modal.options.show = modal.options.show || function (modal) {
@@ -92,6 +91,10 @@ AssetShare.SemanticUI.Modal = (function ($, ns) {
             };
 
             if (!isOpenModal(modal.id)) {
+
+                // in cases like direct download, make sure to close previous window
+                modal.options.closePrevious ? modal.options.closePrevious(htmlResponse, tracker) : false;
+
                 modal.options.show($('<div>' + htmlResponse + "</div>").find(ns.Elements.selector(modal.id)).modal({
                     allowMultiple: false,
                     closable: true,

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/modal.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/modal.js
@@ -92,8 +92,9 @@ AssetShare.SemanticUI.Modal = (function ($, ns) {
 
             if (!isOpenModal(modal.id)) {
 
-                // in cases like direct download, make sure to close previous window
-                modal.options.closePrevious ? modal.options.closePrevious(htmlResponse, tracker) : false;
+                // Provide callback if something needs to be done prior to showing the modal
+                // The existing use-case is for direct downloads; close the previous modal (ie. license, or cart)
+                if (modal.options.beforeShow) { modal.options.beforeShow(htmlResponse, tracker); }
 
                 modal.options.show($('<div>' + htmlResponse + "</div>").find(ns.Elements.selector(modal.id)).modal({
                     allowMultiple: false,

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/_cq_dialog/.content.xml
@@ -257,6 +257,37 @@
                             </column>
                         </items>
                     </tab-2>
+                    <tab-3
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Behavior"
+                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <column
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <download-direct
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/switch"
+                                        emptyText="Download"
+                                        fieldLabel="Enable Direct Download"
+                                        fieldDescription="When enabled, the download modal will not show and selected renditions under Download Options will be requested."
+                                        onText="Direct Downloads"
+                                        offText="Standard Download modal behavior"
+                                        name="./downloadDirect"
+                                        required="{Boolean}false"
+                                        value="true"
+                                        uncheckedValue=""
+                                        deleteHint="{Boolean}true"/>
+                                    <download-direct-note
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/text"
+                                        text="Note* at least ONE rendition must be checked under Download Options for direct downloads to function properly" />
+                                </items>
+                            </column>
+                        </items>
+                    </tab-3>
                 </items>
             </tabs>
         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/_cq_dialog/.content.xml
@@ -283,7 +283,7 @@
                                     <download-direct-note
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/text"
-                                        text="Note* at least ONE rendition must be checked under Download Options for direct downloads to function properly" />
+                                        text="For direct downloads to function properly, at least one rendition option should be checked." />
                                 </items>
                             </column>
                         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/clientlibs/site/js/download.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/clientlibs/site/js/download.js
@@ -48,27 +48,41 @@ jQuery((function(ns, semanticModal, licenseModal, downloadService) {
                 id: DOWNLOAD_MODAL_ID,
                 url: DOWNLOAD_URL,
                 data: formData.serialize(),
-                options: {}
-            };
-
-            if (licensed) {
-                downloadModal.options.show = function (modal) {
-                    modal.modal("attach events", ns.Elements.selector([licenseModal.id(), licenseModal.acceptId()]));
-                };
-            } else {
-                downloadModal.options.show = function (modal) {
-
-                     //direct download (don't show modal)
-                    if($(modal).data(DOWNLOAD_DIRECT)) {
-                        console.log("Direct download!");
-
-                        $(modal).submit().remove();
-                    } else {
-                        // regular modal
-                        modal.modal('show');
+                options: {
+                    closePrevious: function(htmlResponse, modalTracker) {
+                        console.log("IN the close " + licensed);
+                        var modal = $("<div>" + htmlResponse + "</div>").find(ns.Elements.selector(getId()));
+                        if($(modal).data(DOWNLOAD_DIRECT)) {
+                            for(var modalId of modalTracker) {
+                                if(modalId != licenseModal.id()) {
+                                    ns.Elements.element(modalId).modal('hide');
+                                }
+                            }
+                        }
+                    },
+                    show: function(modal) {
+                        // Direct download enabled
+                        if($(modal).data(DOWNLOAD_DIRECT)) {
+                            if(licensed) {
+                                // manually submit the download AFTER license approved clicked
+                                $("body").on("click", ns.Elements.selector([licenseModal.id(), licenseModal.acceptId()]), function (e) {
+                                    $(modal).submit().remove();
+                                });
+                            } else {
+                                $(modal).submit().remove();
+                            }
+                        } else { //normal download modal
+                            if(licensed) {
+                                // open download modal when license modal accepted
+                                modal.modal("attach events", ns.Elements.selector([licenseModal.id(), licenseModal.acceptId()]));
+                            } else {
+                                // regular modal
+                                modal.modal('show');
+                            }
+                        }
                     }
-                };
-            }
+                }
+            };
 
             return downloadModal;
         }

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/clientlibs/site/js/download.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/clientlibs/site/js/download.js
@@ -50,7 +50,6 @@ jQuery((function(ns, semanticModal, licenseModal, downloadService) {
                 data: formData.serialize(),
                 options: {
                     closePrevious: function(htmlResponse, modalTracker) {
-                        console.log("IN the close " + licensed);
                         var modal = $("<div>" + htmlResponse + "</div>").find(ns.Elements.selector(getId()));
                         if($(modal).data(DOWNLOAD_DIRECT)) {
                             for(var modalId of modalTracker) {

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/clientlibs/site/js/download.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/clientlibs/site/js/download.js
@@ -22,6 +22,7 @@ jQuery((function(ns, semanticModal, licenseModal, downloadService) {
     "use strict";
     AssetShare.SemanticUI.Modals.DownloadModal = (function () {
         var DOWNLOAD_URL = ns.Data.val("download-url"),
+            DOWNLOAD_DIRECT = "asset-share-download-direct",
             DOWNLOAD_MODAL_ID = "download-modal",
             DOWNLOAD_BUTTON_ID = "download-asset",
             DOWNLOAD_MODE_ASYNC = "data-asset-share-mode-async";
@@ -56,7 +57,16 @@ jQuery((function(ns, semanticModal, licenseModal, downloadService) {
                 };
             } else {
                 downloadModal.options.show = function (modal) {
-                    modal.modal('show');
+
+                     //direct download (don't show modal)
+                    if($(modal).data(DOWNLOAD_DIRECT)) {
+                        console.log("Direct download!");
+
+                        $(modal).submit().remove();
+                    } else {
+                        // regular modal
+                        modal.modal('show');
+                    }
                 };
             }
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/clientlibs/site/js/download.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/clientlibs/site/js/download.js
@@ -49,11 +49,12 @@ jQuery((function(ns, semanticModal, licenseModal, downloadService) {
                 url: DOWNLOAD_URL,
                 data: formData.serialize(),
                 options: {
-                    closePrevious: function(htmlResponse, modalTracker) {
+                    // Download modal's beforeShow(..) has code to ensure that any previous modals are closed before opening the download window, specifically for the case of the Direct Download
+                    beforeShow: function(htmlResponse, modalTracker) {
                         var modal = $("<div>" + htmlResponse + "</div>").find(ns.Elements.selector(getId()));
                         if($(modal).data(DOWNLOAD_DIRECT)) {
                             for(var modalId of modalTracker) {
-                                if(modalId != licenseModal.id()) {
+                                if(modalId !== licenseModal.id()) {
                                     ns.Elements.element(modalId).modal('hide');
                                 }
                             }

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
@@ -35,7 +35,7 @@
           target="download"
           data-asset-share-id="download-modal"
           data-asset-share-mode-async="${download.isAsynchronous ? 'true' : ''}"
-          data-asset-share-download-direct="true"
+          data-asset-share-download-direct="${properties.downloadDirect ? 'true' : ''}"
           class="ui modal cmp-modal-download--wrapper cmp-modal">
 
     <i class="close icon"></i>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
@@ -38,7 +38,9 @@
           class="ui modal cmp-modal-download--wrapper cmp-modal">
 
     <i class="close icon"></i>
-
+    <div data-sly-test="${properties.downloadDirect}" class="ui warning message">
+        <div class="header">${"Direct Downloads enabled" @ i18n}</div>
+    </div>
     <div class="header">
         ${properties['modalTitle']}
     </div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
@@ -28,12 +28,14 @@
     }
 </style>
 
+ <!--/* hard coded for download direct property for now... */-->
 <form data-sly-test="${!legacyMode}"
           method="post"
           action="${resource.path @ selectors = 'download-asset-renditions', extension = 'zip'}"
           target="download"
           data-asset-share-id="download-modal"
           data-asset-share-mode-async="${download.isAsynchronous ? 'true' : ''}"
+          data-asset-share-download-direct="true"
           class="ui modal cmp-modal-download--wrapper cmp-modal">
 
     <i class="close icon"></i>
@@ -86,7 +88,7 @@
                 </sly>
             </div>
             </sly>
-        </div>        
+        </div>
     </div>
 
     <div class="actions cmp-footer__actions">

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
@@ -28,7 +28,6 @@
     }
 </style>
 
- <!--/* hard coded for download direct property for now... */-->
 <form data-sly-test="${!legacyMode}"
           method="post"
           action="${resource.path @ selectors = 'download-asset-renditions', extension = 'zip'}"


### PR DESCRIPTION
- adds new tab to Download dialog
- allows user to enable Direct Downloads
- when enabled, the download dialog modal will not appear. Instead it will be submitted silently. In order to function properly at least one rendition should be selected. The safest (and easiest) approach is to use direct downloads with the **original** rendition, since all asset types will have this. However it is also possible to check multiple renditions (assuming that all of the assets users can download will include this)
- Other modals continue to appear (License, Cart) and when the Download modal is called it will auto-submit the download.

Dialog option:
![image](https://user-images.githubusercontent.com/8974514/112398318-2a3ab780-8cc1-11eb-9e2d-0fb2fcd0c06e.png)

When direct download enabled a warning appears when editing the Download Modal (will never be shown to the end user)
![image](https://user-images.githubusercontent.com/8974514/112399627-cf568f80-8cc3-11eb-97da-6c55249e387b.png)
