### PR TITLE
2.0.0/Cloud Manager code quality

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/Download.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/Download.java
@@ -22,8 +22,10 @@ package com.adobe.aem.commons.assetshare.components.actions.download;
 import com.adobe.aem.commons.assetshare.content.AssetModel;
 import com.adobe.cq.wcm.core.components.models.form.OptionItem;
 import com.adobe.cq.wcm.core.components.models.form.Options;
+import com.google.common.collect.ImmutableList;
 import org.osgi.annotation.versioning.ProviderType;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -85,7 +87,7 @@ public interface Download {
 
         public AssetRenditionsGroup(String title, List<OptionItem> options) {
             this.title = title;
-            this.options = options;
+            this.options = new ArrayList<>(options);
         }
 
         public String getTitle() {
@@ -93,7 +95,7 @@ public interface Download {
         }
 
         public List<OptionItem> getItems() {
-            return options;
+            return ImmutableList.copyOf(options);
         }
     }
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/downloads/impl/PlaceholderDownloadProgress.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/downloads/impl/PlaceholderDownloadProgress.java
@@ -2,6 +2,8 @@ package com.adobe.aem.commons.assetshare.components.actions.downloads.impl;
 
 import com.adobe.cq.dam.download.api.DownloadArtifact;
 import com.adobe.cq.dam.download.api.DownloadProgress;
+import com.google.common.collect.ImmutableList;
+import org.apache.http.entity.mime.MIME;
 
 import java.net.URI;
 import java.util.*;
@@ -106,7 +108,7 @@ public class PlaceholderDownloadProgress implements DownloadProgress {
 
         @Override
         public String getMimeType() {
-            return "application/zip";
+            return  "application/zip";
         }
 
         @Override
@@ -124,7 +126,7 @@ public class PlaceholderDownloadProgress implements DownloadProgress {
 
         @Override
         public Collection<String> getSuccesses() {
-            return successes;
+            return ImmutableList.copyOf(successes);
         }
 
         @Override

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/AssetModelImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/impl/AssetModelImpl.java
@@ -49,6 +49,7 @@ import java.util.List;
         adapters = { AssetModel.class },
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )
+@SuppressWarnings("AEM Rules:AEM-16") // The Default Optional strategy is infact required
 public class AssetModelImpl implements AssetModel {
 
     @Self

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/async/impl/AsyncAssetRenditionsDownloadServlet.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/async/impl/AsyncAssetRenditionsDownloadServlet.java
@@ -71,16 +71,16 @@ public class AsyncAssetRenditionsDownloadServlet extends SlingAllMethodsServlet 
     private static final String DOWNLOAD_ARCHIVE_NAME = PARAM_ARCHIVE_NAME;
 
     @Reference(target="(distribution=cloud-ready)")
-    private RequireAem requireAem;
+    private transient RequireAem requireAem;
 
     @Reference
-    private ActionHelper actionHelper;
+    private transient ActionHelper actionHelper;
 
     @Reference
-    private DownloadService downloadService;
+    private transient DownloadService downloadService;
 
     @Reference
-    private DownloadApiFactory apiFactory;
+    private transient DownloadApiFactory apiFactory;
 
     @Override
     protected final void doPost(final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws ServletException, IOException {

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/impl/AssetRenditionDownloadRequest.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/impl/AssetRenditionDownloadRequest.java
@@ -30,6 +30,9 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.script.SimpleBindings;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import static org.apache.sling.api.scripting.SlingBindings.*;
 
 public class AssetRenditionDownloadRequest extends SlingHttpServletRequestWrapper {
@@ -50,7 +53,11 @@ public class AssetRenditionDownloadRequest extends SlingHttpServletRequestWrappe
 
         this.resource = resource;
         this.method = method;
-        this.selectors = selectors;
+        if (selectors != null) {
+            this.selectors = Arrays.copyOf(selectors, selectors.length);
+        } else {
+            this.selectors = new String[]{};
+        }
         this.extension = extension;
         this.suffix = suffix;
 
@@ -121,7 +128,7 @@ public class AssetRenditionDownloadRequest extends SlingHttpServletRequestWrappe
             @Nonnull
             @Override
             public String[] getSelectors() {
-                return selectors;
+                return Arrays.copyOf(selectors, selectors.length);
             }
 
             @CheckForNull

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/impl/AssetRenditionsDownloadServlet.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/impl/AssetRenditionsDownloadServlet.java
@@ -81,18 +81,18 @@ public class AssetRenditionsDownloadServlet extends SlingAllMethodsServlet imple
     private static final String DEFAULT_ASSET_RENDITIONS_DOWNLOAD_ORCHESTRATOR = AssetRenditionsZipperImpl.class.getName();
 
     @Reference(target="(distribution=classic)")
-    private RequireAem requireAem;
+    private transient RequireAem requireAem;
 
     @Reference
-    private ServletHelper servletHelper;
+    private transient ServletHelper servletHelper;
 
     @Reference
-    private ModelFactory modelFactory;
+    private transient ModelFactory modelFactory;
 
     @Reference
-    private ActionHelper actionHelper;
+    private transient ActionHelper actionHelper;
 
-    private Map<String, AssetRenditionsDownloadOrchestrator> assetRenditionsDownloadOrchestrators = new ConcurrentHashMap<>();
+    private transient Map<String, AssetRenditionsDownloadOrchestrator> assetRenditionsDownloadOrchestrators = new ConcurrentHashMap<>();
 
     @Override
     protected final void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response) throws ServletException, IOException {


### PR DESCRIPTION
Fixes issues called out by Cloud Manager code quality.

The only ones left should be use of deprecated APIs (most are our own deprecations which can kill in 3.0.0) but also a few for things like SlingSettingsService (for stuff like EditorLinks that should only work on AEM Author)