### PR TITLE
2.0.0/tuesday

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -74,12 +74,7 @@
                             <type>zip</type>
                             <target>/apps/asset-share-commons-packages/content/install</target>
                         </embedded>
-                        <embedded>
-                            <groupId>com.adobe.aem.commons</groupId>
-                            <artifactId>assetshare.ui.content.sample</artifactId>
-                            <type>zip</type>
-                            <target>/apps/asset-share-commons-packages/content/install</target>
-                        </embedded>
+                        <!-- Remove ui.contnet.sample from all package, as it should not be installed as part of real uses of Asset Share commons -->
                     </embeddeds>
                     <allowIndexDefinitions>true</allowIndexDefinitions>
                     <dependencies>

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/Download.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/Download.java
@@ -72,6 +72,9 @@ public interface Download {
      */
     boolean isAsynchronous();
 
+    @Deprecated
+    default boolean isLegacyMode() { return false; }
+
     default List<AssetRenditionsGroup> getAssetRenditionsGroups() {
         return Collections.EMPTY_LIST;
     }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/impl/DownloadImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/impl/DownloadImpl.java
@@ -198,15 +198,13 @@ public class DownloadImpl implements Download, ComponentExporter {
 
     @Override
     public boolean isAsynchronous() {
-        if (RequireAem.Distribution.CLASSIC.equals(requireAem.getDistribution())) {
-            // async downloads only available in the cloud, return false
-            return false;
-        }
-        return true;
+        // async downloads only available in the cloud
+        return RequireAem.Distribution.CLOUD_READY.equals(requireAem.getDistribution());
     }
 
     @Deprecated
-    protected boolean isLegacyMode() {
+    @Override
+    public boolean isLegacyMode() {
         if (legacyMode == null) {
             if (getAssetRenditionsGroups() != null && !getAssetRenditionsGroups().isEmpty()) {
                 // Is the new renditions exist, then assume modern

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/ConfigImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/ConfigImpl.java
@@ -24,6 +24,7 @@ import com.adobe.aem.commons.assetshare.configuration.Config;
 import com.adobe.aem.commons.assetshare.configuration.impl.selectors.AlwaysUseDefaultSelectorImpl;
 import com.adobe.aem.commons.assetshare.content.AssetModel;
 import com.adobe.aem.commons.assetshare.util.ForcedInheritanceValueMapWrapper;
+import com.adobe.aem.commons.assetshare.util.RequireAem;
 import com.adobe.granite.contexthub.api.ContextHub;
 import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
 import com.day.cq.wcm.api.Page;
@@ -98,6 +99,10 @@ public class ConfigImpl implements Config {
     @OSGiService
     @Required
     private ModelFactory modelFactory;
+
+    @OSGiService
+    @Required
+    private RequireAem requireAem;
 
     @OSGiService(injectionStrategy = InjectionStrategy.OPTIONAL)
     private ShareService shareService;
@@ -289,6 +294,11 @@ public class ConfigImpl implements Config {
         }
 
         return false;
+    }
+
+    @Override
+    public boolean isAemClassic() {
+        return RequireAem.Distribution.CLASSIC.equals(requireAem.getDistribution());
     }
 
     /**

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/css.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/css.txt
@@ -2,3 +2,4 @@
 
 grid.less
 main.less
+modals.less

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/less/modals.less
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/less/modals.less
@@ -1,7 +1,7 @@
 /*
  * Asset Share Commons
  *
- * Copyright [2017]  Adobe
+ * Copyright [2021]  Adobe
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,13 @@
  * limitations under the License.
  */
 
-.cmp-modal-cart {
-    .cmp-modal-cart__empty-text {
-        text-transform: uppercase;
-        text-align: center;
-        height: 100px;
-        line-height: 100px;
+@import (once) "variables.less";
 
-    }
+/* Contains common modal styles */
 
-    td {
-        border-width: 0 !important;
+.cmp-modal {
+    .scrolling.content {
+        overflow-y: scroll;
+        max-height: calc(~"100vh - 400px");
     }
 }

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/accordion/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/accordion/.content.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:isContainer="{Boolean}true"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="Accordion"
+    sling:resourceSuperType="core/wcm/components/accordion/v1/accordion"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/accordion/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/accordion/_cq_editConfig.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:EditConfig">
+    <cq:listeners
+        jcr:primaryType="cq:EditListenersConfig"
+        afterchilddelete="CQ.CoreComponents.panelcontainer.v1.AFTER_CHILD_DELETE"
+        afterchildinsert="CQ.CoreComponents.panelcontainer.v1.AFTER_CHILD_INSERT"
+        afterchildmove="CQ.CoreComponents.panelcontainer.v1.AFTER_CHILD_MOVE"/>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/accordion/_cq_template/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/accordion/_cq_template/.content.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+    xmlns:jcr="http://www.jcp.org/jcr/1.0" jcr:primaryType="nt:unstructured">
+    <item_1 jcr:primaryType="nt:unstructured"
+        jcr:title="Item 1"
+        sling:resourceType="examples/components/container"
+        layout="responsiveGrid"/>
+    <item_2 jcr:primaryType="nt:unstructured"
+        jcr:title="Item 2"
+        sling:resourceType="examples/components/container"
+        layout="responsiveGrid"/>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/breadcrumb/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/breadcrumb/.content.xml
@@ -1,24 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Asset Share Commons
-  ~
-  ~ Copyright [2017]  Adobe
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:description="Displays the position of the current page within the site hierarchy"
     jcr:primaryType="cq:Component"
     jcr:title="Breadcrumb"
     sling:resourceSuperType="core/wcm/components/breadcrumb/v2/breadcrumb"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/button/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/button/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="Button"
+    sling:resourceSuperType="core/wcm/components/button/v1/button"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/carousel/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/carousel/.content.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:isContainer="{Boolean}true"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="Carousel"
+    sling:resourceSuperType="core/wcm/components/carousel/v1/carousel"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/carousel/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/carousel/_cq_editConfig.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:EditConfig">
+    <cq:listeners
+        jcr:primaryType="cq:EditListenersConfig"
+        afterchilddelete="CQ.CoreComponents.panelcontainer.v1.AFTER_CHILD_DELETE"
+        afterchildinsert="CQ.CoreComponents.panelcontainer.v1.AFTER_CHILD_INSERT"
+        afterchildmove="CQ.CoreComponents.panelcontainer.v1.AFTER_CHILD_MOVE"/>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/container/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/container/.content.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:isContainer="{Boolean}true"
+    cq:styleElements="[div,section,article,main,aside,header,footer]"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="Container"
+    sling:resourceSuperType="core/wcm/components/container/v1/container"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/contentfragment/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/contentfragment/.content.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:styleElements="[div,section,article,main,aside,header,footer]"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="Content Fragment"
+    sling:resourceSuperType="core/wcm/components/contentfragment/v1/contentfragment"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/contentfragment/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/contentfragment/_cq_editConfig.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:EditConfig">
+    <cq:inplaceEditing
+        jcr:primaryType="cq:InplaceEditingConfig"
+        active="{Boolean}true"
+        editorType="contentfragment"/>
+    <cq:dropTargets jcr:primaryType="nt:unstructured">
+        <contentfragment
+            jcr:primaryType="cq:DropTargetConfig"
+            accept="[application/vnd.adobe.contentfragment]"
+            groups="[media]"
+            propertyName="./fragmentPath">
+            <parameters
+                jcr:primaryType="nt:unstructured"
+                displayMode="multi"
+                elementNames=""
+                paragraphHeadings=""
+                paragraphRange=""
+                paragraphScope=""
+                variationName=""/>
+        </contentfragment>
+    </cq:dropTargets>
+    <cq:listeners
+        jcr:primaryType="cq:EditListenersConfig"
+        afterdelete="function (properties) { $(document).trigger('cq-contentfragment-delete'); }"
+        afteredit="function (properties) { $(document).trigger('cq-contentfragment-edit'); }"
+        afterinsert="function (properties) { $(document).trigger('cq-contentfragment-insert'); }"/>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/contentfragmentlist/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/contentfragmentlist/.content.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:styleElements="[div,section,article,main,aside,header,footer]"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="Content Fragment List"
+    sling:resourceSuperType="core/wcm/components/contentfragmentlist/v1/contentfragmentlist"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/download/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/download/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="Download"
+    sling:resourceSuperType="core/wcm/components/download/v1/download"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/embed/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/embed/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="Embed"
+    sling:resourceSuperType="core/wcm/components/embed/v1/embed"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/experiencefragment/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/experiencefragment/.content.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:styleElements="[div,section,article,main,aside,header,footer]"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="Experience Fragment"
+    sling:resourceSuperType="core/wcm/components/experiencefragment/v1/experiencefragment"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/experiencefragment/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/experiencefragment/_cq_editConfig.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    cq:actions="[EDIT,DELETE,INSERT,COPYMOVE]"
+    jcr:primaryType="cq:EditConfig">
+    <cq:dropTargets jcr:primaryType="nt:unstructured">
+        <experiencefragment
+            jcr:primaryType="cq:DropTargetConfig"
+            accept="[text/html]"
+            groups="[content]"
+            propertyName="./fragmentVariationPath"/>
+    </cq:dropTargets>
+    <cq:listeners
+        jcr:primaryType="nt:unstructured"
+        afterinsert="REFRESH_PAGE"/>
+    <cq:actionConfigs jcr:primaryType="nt:unstructured">
+        <editInNewTab
+            jcr:primaryType="nt:unstructured"
+            handler="Granite.author.experienceFragments &amp;&amp; Granite.author.experienceFragments.actions.editInNewTab"
+            icon="edit"
+            text="Edit"/>
+    </cq:actionConfigs>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/form/button/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/form/button/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
-    componentGroup="Asset Share Commons - Content"/>
+    jcr:title="Form Button"
+    sling:resourceSuperType="core/wcm/components/form/button/v2/button"
+    componentGroup="AEM examples - Form"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/form/container/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/form/container/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="Form Container"
+    jcr:description="Container for components that allow users to submit information"
+    sling:resourceSuperType="core/wcm/components/form/container/v2/container"
+    componentGroup="AEM examples - Form"
+    cq:isContainer="{Boolean}true"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/form/container/new/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/form/container/new/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+  jcr:primaryType="cq:Component"
+  jcr:title="New Paragraph - Form Container"
+  sling:resourceSuperType="core/wcm/components/form/container/v2/container/new"
+  componentGroup=".hidden"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/form/hidden/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/form/hidden/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
-    componentGroup="Asset Share Commons - Content"/>
+    jcr:title="Form Hidden"
+    sling:resourceSuperType="core/wcm/components/form/hidden/v2/hidden"
+    componentGroup="AEM examples - Form"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/form/options/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/form/options/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
-    componentGroup="Asset Share Commons - Content"/>
+    jcr:title="Form Options"
+    sling:resourceSuperType="core/wcm/components/form/options/v2/options"
+    componentGroup="AEM examples - Form"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/form/text/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/form/text/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
-    componentGroup="Asset Share Commons - Content"/>
+    jcr:title="Form Text"
+    sling:resourceSuperType="core/wcm/components/form/text/v2/text"
+    componentGroup="AEM examples - Form"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/image/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/image/.content.xml
@@ -1,24 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Asset Share Commons
-  ~
-  ~ Copyright [2017]  Adobe
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:description="Smart Adaptive Image"
     jcr:primaryType="cq:Component"
     jcr:title="Image"
     sling:resourceSuperType="core/wcm/components/image/v2/image"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/image/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/image/_cq_editConfig.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:EditConfig">
+    <cq:dropTargets jcr:primaryType="nt:unstructured">
+        <image
+            jcr:primaryType="cq:DropTargetConfig"
+            accept="[image/gif,image/jpeg,image/png,image/webp,image/tiff,image/svg\\+xml]"
+            groups="[media]"
+            propertyName="./fileReference">
+            <parameters
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="examples/components/image"
+                imageCrop=""
+                imageMap=""
+                imageRotate=""/>
+        </image>
+    </cq:dropTargets>
+    <cq:inplaceEditing
+        jcr:primaryType="cq:InplaceEditingConfig"
+        active="{Boolean}true"
+        editorType="image">
+        <config jcr:primaryType="nt:unstructured">
+            <plugins jcr:primaryType="nt:unstructured">
+                <crop
+                    jcr:primaryType="nt:unstructured"
+                    supportedMimeTypes="[image/jpeg,image/png,image/webp,image/tiff]"
+                    features="*">
+                    <aspectRatios jcr:primaryType="nt:unstructured">
+                        <wideLandscape
+                            jcr:primaryType="nt:unstructured"
+                            name="Wide Landscape"
+                            ratio="0.6180"/>
+                        <landscape
+                            jcr:primaryType="nt:unstructured"
+                            name="Landscape"
+                            ratio="0.8284"/>
+                        <square
+                            jcr:primaryType="nt:unstructured"
+                            name="Square"
+                            ratio="1"/>
+                        <portrait
+                            jcr:primaryType="nt:unstructured"
+                            name="Portrait"
+                            ratio="1.6180"/>
+                    </aspectRatios>
+                </crop>
+                <flip
+                    jcr:primaryType="nt:unstructured"
+                    supportedMimeTypes="[image/jpeg,image/png,image/webp,image/tiff]"
+                    features="-"/>
+                <map
+                    jcr:primaryType="nt:unstructured"
+                    supportedMimeTypes="[image/jpeg,image/png,image/webp,image/tiff,image/svg+xml]"
+                    features="*"/>
+                <rotate
+                    jcr:primaryType="nt:unstructured"
+                    supportedMimeTypes="[image/jpeg,image/png,image/webp,image/tiff]"
+                    features="*"/>
+                <zoom
+                    jcr:primaryType="nt:unstructured"
+                    supportedMimeTypes="[image/jpeg,image/png,image/webp,image/tiff]"
+                    features="*"/>
+            </plugins>
+            <ui jcr:primaryType="nt:unstructured">
+                <inline
+                    jcr:primaryType="nt:unstructured"
+                    toolbar="[crop#launch,rotate#right,history#undo,history#redo,fullscreen#fullscreen,control#close,control#finish]">
+                    <replacementToolbars
+                        jcr:primaryType="nt:unstructured"
+                        crop="[crop#identifier,crop#unlaunch,crop#confirm]"/>
+                </inline>
+                <fullscreen jcr:primaryType="nt:unstructured">
+                    <toolbar
+                        jcr:primaryType="nt:unstructured"
+                        left="[crop#launchwithratio,rotate#right,flip#horizontal,flip#vertical,zoom#reset100,zoom#popupslider]"
+                        right="[history#undo,history#redo,fullscreen#fullscreenexit]"/>
+                    <replacementToolbars jcr:primaryType="nt:unstructured">
+                        <crop
+                            jcr:primaryType="nt:unstructured"
+                            left="[crop#identifier]"
+                            right="[crop#unlaunch,crop#confirm]"/>
+                        <map
+                            jcr:primaryType="nt:unstructured"
+                            left="[map#rectangle,map#circle,map#polygon]"
+                            right="[map#unlaunch,map#confirm]"/>
+                    </replacementToolbars>
+                </fullscreen>
+            </ui>
+        </config>
+    </cq:inplaceEditing>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/languagenavigation/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/languagenavigation/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
-    componentGroup="Asset Share Commons - Content"/>
+    jcr:title="Language Navigation"
+    sling:resourceSuperType="core/wcm/components/languagenavigation/v1/languagenavigation"
+    componentGroup="AEM examples - Structure"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/list/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/list/.content.xml
@@ -1,24 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Asset Share Commons
-  ~
-  ~ Copyright [2017]  Adobe
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:description="Configurable collection of items or content"
     jcr:primaryType="cq:Component"
     jcr:title="List"
     sling:resourceSuperType="core/wcm/components/list/v2/list"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/list/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/list/_cq_editConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:EditConfig">
+    <cq:dropTargets jcr:primaryType="cq:DropTargetConfig">
+        <pages
+            jcr:primaryType="nt:unstructured"
+            accept="[*]"
+            groups="[page]"
+            propertyName="./pages">
+            <parameters
+                jcr:primaryType="nt:unstructured"
+                listFrom="static"/>
+        </pages>
+    </cq:dropTargets>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/navigation/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/navigation/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
-    componentGroup="Asset Share Commons - Content"/>
+    jcr:title="Navigation"
+    sling:resourceSuperType="core/wcm/components/navigation/v1/navigation"
+    componentGroup="AEM examples - Structure"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/pdfviewer/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/pdfviewer/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="PDF Viewer"
+    sling:resourceSuperType="core/wcm/components/pdfviewer/v1/pdfviewer"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/progressbar/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/progressbar/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="Progress Bar"
+    sling:resourceSuperType="core/wcm/components/progressbar/v1/progressbar"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/separator/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/separator/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="Separator"
+    sling:resourceSuperType="core/wcm/components/separator/v1/separator"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/sharing/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/sharing/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="Social Media Sharing"
+    sling:resourceSuperType="core/wcm/components/sharing/v1/sharing"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/tabs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/tabs/.content.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:isContainer="{Boolean}true"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
+    jcr:title="Tabs"
+    sling:resourceSuperType="core/wcm/components/tabs/v1/tabs"
     componentGroup="Asset Share Commons - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/tabs/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/tabs/_cq_editConfig.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:EditConfig">
+    <cq:listeners
+        jcr:primaryType="cq:EditListenersConfig"
+        afterchilddelete="CQ.CoreComponents.panelcontainer.v1.AFTER_CHILD_DELETE"
+        afterchildinsert="CQ.CoreComponents.panelcontainer.v1.AFTER_CHILD_INSERT"
+        afterchildmove="CQ.CoreComponents.panelcontainer.v1.AFTER_CHILD_MOVE"/>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/tabs/_cq_template/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/tabs/_cq_template/.content.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured">
+    <item_1
+        jcr:primaryType="nt:unstructured"
+        jcr:title="Tab 1"
+        sling:resourceType="examples/components/container"
+        layout="responsiveGrid"/>
+    <item_2
+        jcr:primaryType="nt:unstructured"
+        jcr:title="Tab 2"
+        sling:resourceType="examples/components/container"
+        layout="responsiveGrid"/>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/teaser/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/teaser/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+    xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="Teaser"
+    sling:resourceSuperType="core/wcm/components/teaser/v1/teaser"
+    componentGroup="Asset Share Commons - Content"
+    imageDelegate="examples/components/image"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/text/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/text/.content.xml
@@ -1,24 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Asset Share Commons
-  ~
-  ~ Copyright [2017]  Adobe
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:description="Rich Text Section"
     jcr:primaryType="cq:Component"
     jcr:title="Text"
     sling:resourceSuperType="core/wcm/components/text/v2/text"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/xfpage/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/xfpage/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v2/title"
-    componentGroup="Asset Share Commons - Content"/>
+    jcr:title="AEM examples Experience Fragment"
+    sling:resourceSuperType="cq/experience-fragments/components/xfpage"
+    componentGroup=".hidden"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/xfpage/content.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/xfpage/content.html
@@ -1,0 +1,16 @@
+<!--/*
+    Copyright 2019 Adobe
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/-->
+<sly data-sly-use.body="body.js" data-sly-resource="${body.resourcePath @ selectors=[]}"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/xfpage/customfooterlibs.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/xfpage/customfooterlibs.html
@@ -1,0 +1,18 @@
+<!--/*
+    Copyright 2019 Adobe
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/-->
+<sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
+    <sly data-sly-call="${clientlib.js @ categories='examples.base'}"/>
+</sly>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/xfpage/customheaderlibs.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/content/xfpage/customheaderlibs.html
@@ -1,0 +1,23 @@
+<!--/*
+    Copyright 2019 Adobe
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/-->
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<sly data-sly-use.clientLib="/libs/granite/sightly/templates/clientlib.html"
+     data-sly-call="${clientlib.js @ categories='examples.dependencies'}"/>
+<sly data-sly-use.clientLib="/libs/granite/sightly/templates/clientlib.html"
+     data-sly-call="${clientlib.css @ categories='examples.base'}"/>
+
+<!--/* Include Context Hub */-->
+<sly data-sly-resource="${'contexthub' @ resourceType='granite/contexthub/components/contexthub'}"/>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/_cq_dialog/.content.xml
@@ -185,6 +185,33 @@
                                             emptyText="Leave blank to hide Select All control"
                                             name="./selectAllLabel"/>
 
+                                    <achive-name-expression
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                            emptyText="Asset Archive (${asset.count} assets)"
+                                            fieldDescription="The file name expression that defines the download archive file name."
+                                            fieldLabel="Archive Name Expression"
+                                            name="./archiveNameExpression"
+                                            required="{Boolean}false">
+                                        <granite:rendercondition
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="asset-share-commons/authoring/renderconditions/require-aem"
+                                                distribution="cloud-ready"/>
+                                    </achive-name-expression>
+
+                                    <!-- AEM Classic -->
+
+                                    <achive-name-expression-note
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/hyperlink"
+                                            text="Click to see the available expression variables"
+                                            href="https://adobe-marketing-cloud.github.io/asset-share-commons/pages/actions/download#archive-name-expression">
+                                        <granite:rendercondition
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="asset-share-commons/authoring/renderconditions/require-aem"
+                                                distribution="cloud-ready"/>
+                                    </achive-name-expression-note>
+
                                     <exclude-original-assets
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
@@ -199,63 +226,22 @@
                                                 distribution="classic"/>
                                     </exclude-original-assets>
 
-                                    <achive-name-expression
+                                    <!-- ./fileName is the Classic Mode property name -->
+                                    <download-file-name
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                            emptyText="Asset Archive (${asset.count} assets)"
-                                            fieldDescription="The file name expression that defines the download archive file name."
-                                            fieldLabel="Archive Name Expression"
-                                            name="./archiveNameExpression"
-                                            required="{Boolean}false"/>
+                                            emptyText="Assets"
+                                            fieldDescription="The name of the file that a user will download."
+                                            fieldLabel="File Name"
+                                            name="./fileName"
+                                            required="{Boolean}false">
+                                        <granite:rendercondition
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="asset-share-commons/authoring/renderconditions/require-aem"
+                                                distribution="classic"/>
+                                    </download-file-name>
 
-                                    <achive-name-expression-note
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="granite/ui/components/coral/foundation/text"
-                                            text="The Asset Archive Expression supports the following expression variables:" />
-
-                                    <achive-name-expression-list
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="granite/ui/components/foundation/layouts/list">
-                                        <items jcr:primaryType="nt:unstructured">
-                                            <item0 jcr:primaryType="nt:unstructured"
-                                                   sling:resourceType="granite/ui/components/coral/foundation/text"
-                                                   text="${'${'}asset.count}}: Number of assets selected as part of this download"/>
-                                            <item1 jcr:primaryType="nt:unstructured"
-                                                   sling:resourceType="granite/ui/components/coral/foundation/text"
-                                                   text="${'${'}rendition.count}}: Number of renditions selected as part of this download"/>
-                                            <item2 jcr:primaryType="nt:unstructured"
-                                                   sling:resourceType="granite/ui/components/coral/foundation/text"
-                                                   text="${'${'}file.count}: Number of assets X number of renditions. This is not always accurate as not all assets may be able to provide all renditions."/>
-                                            <item3 jcr:primaryType="nt:unstructured"
-                                                   sling:resourceType="granite/ui/components/coral/foundation/text"
-                                                   text="${'${'}year}: The current year"/>
-                                            <item4 jcr:primaryType="nt:unstructured"
-                                                   sling:resourceType="granite/ui/components/coral/foundation/text"
-                                                   text="${'${'}month}: The current month (1-12)"/>
-                                            <item5 jcr:primaryType="nt:unstructured"
-                                                   sling:resourceType="granite/ui/components/coral/foundation/text"
-                                                   text="${'${'}month.name}: The current month's name (ex. Jan)"/>
-                                            <item6 jcr:primaryType="nt:unstructured"
-                                                   sling:resourceType="granite/ui/components/coral/foundation/text"
-                                                   text="${'${'}day}: The current day (1-31)"/>
-                                            <item7 jcr:primaryType="nt:unstructured"
-                                                   sling:resourceType="granite/ui/components/coral/foundation/text"
-                                                   text="${'${'}day.name}: The current day's name (ex. Mon)"/>
-                                            <item8 jcr:primaryType="nt:unstructured"
-                                                   sling:resourceType="granite/ui/components/coral/foundation/text"
-                                                   text="${'${'}hour.12}: The current hour (12 hour clock)"/>
-                                            <item9 jcr:primaryType="nt:unstructured"
-                                                   sling:resourceType="granite/ui/components/coral/foundation/text"
-                                                   text="${'${'}hour.24}: The current hour (24 hour clock)"/>
-                                            <item10 jcr:primaryType="nt:unstructured"
-                                                   sling:resourceType="granite/ui/components/coral/foundation/text"
-                                                   text="${'${'}minute}: The current minute"/>
-                                            <item11 jcr:primaryType="nt:unstructured"
-                                                   sling:resourceType="granite/ui/components/coral/foundation/text"
-                                                   text="${'${'}am.pm}: The current time's AM or PM designation"/>
-                                        </items>
-                                    </achive-name-expression-list>
-
+                                    <!-- ./zipFileName is the Legacy Mode property name -->
                                     <zip-file-name
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/clientlibs/site/js/download.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/clientlibs/site/js/download.js
@@ -51,6 +51,7 @@ jQuery((function(ns, semanticModal, licenseModal, downloadService) {
                 options: {
                     // Download modal's beforeShow(..) has code to ensure that any previous modals are closed before opening the download window, specifically for the case of the Direct Download
                     beforeShow: function(htmlResponse, modalTracker) {
+                    debugger
                         var modal = $("<div>" + htmlResponse + "</div>").find(ns.Elements.selector(getId()));
                         if($(modal).data(DOWNLOAD_DIRECT)) {
                             for(var modalId of modalTracker) {

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
@@ -110,7 +110,6 @@
 </form>
 
 
-
 <!--/* Load Legacy Template */-->
 <sly data-sly-test="${legacyMode}"
      data-sly-call="${legacyTemplate.legacy @ download=download}"></sly>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/downloads/clientlibs/site/less/modal.less
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/downloads/clientlibs/site/less/modal.less
@@ -18,6 +18,10 @@
 
 .cmp-modal-downloads {
 
+   .ui.accordion-content {
+        cursor: pointer;
+    }
+
     .ui.accordion-content {
         display: none;
     }
@@ -29,7 +33,7 @@
     .cmp-modal-downloads__table {
         width: 100%;
         border-collapse: collapse;
-        font-size: 1em !important;
+        font-size: 1em;
     }
 
     .cmp-modal-downloads__col--action,

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/downloads/downloads.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/downloads/downloads.html
@@ -19,81 +19,86 @@
 <sly
         data-sly-use.modelCache="com.adobe.aem.commons.assetshare.util.ModelCache"
         data-sly-test.config="${modelCache['com.adobe.aem.commons.assetshare.configuration.Config']}"
+        data-sly-test="${!config.aemClassic}"
         data-sly-use.downloads="com.adobe.aem.commons.assetshare.components.actions.downloads.Downloads"
         data-sly-test.hasDownloads="${downloads.downloads.size > 0}"
         data-sly-use.downloadTemplate="templates/download.html"
-        data-sly-use.placeholderTemplate="core/wcm/components/commons/v1/templates.html"></sly>
+        data-sly-use.placeholderTemplate="core/wcm/components/commons/v1/templates.html">
 
-<sly data-sly-test="${!wccmode.disabled}"/>
-    <script>
-        $(function() {
-            AssetShare.SemanticUI.Modals.DownloadsModal.init();
-        });
-    </script>
+    <sly data-sly-test="${!wccmode.disabled}">
+        <script>
+            $(function() {
+                AssetShare.SemanticUI.Modals.DownloadsModal.init();
+            });
+        </script>
 
-    <style>
-        .cmp-modal-downloads .ui.modal {
-            position: relative !important;
-            display: block !important;
-            top: 0 !important;
-        }
-    </style>
+        <style>
+            .cmp-modal-downloads .ui.modal {
+                position: relative !important;
+                display: block !important;
+                top: 0 !important;
+            }
+        </style>
+    </sly>
+
+    <div data-asset-share-id="downloads-modal"
+         data-asset-share-update-method="replace"
+         data-asset-share-update-when="downloads-updated"
+         data-asset-share-downloads-count="${downloads.downloads.size}"
+         class="ui long modal cmp-modal cmp-modal-downloads">
+        <i class="close icon"></i>
+
+        <div class="header">
+            ${properties.modalTitle || 'Downloads' @i18n}
+            <span data-sly-test="${hasDownloads}"
+                    data-asset-share-id="refresh-downloads">
+                    <a href="#refresh"><i class="cmp-modal-downloads__refresh sync alternate icon"></i></a>
+            </span>
+        </div>
+
+        <div class="scrolling content">
+
+            <div class="ui container">
+
+                <table class="cmp-modal-downloads__table"
+                       data-sly-test="${hasDownloads}">
+                    <thead class="cmp-modal-downloads__table-header">
+                        <tr>
+                            <th class="cmp-modal-downloads__col--archive-name"></th>
+                            <th class="cmp-modal-downloads__col--file-status">${ properties.statusColumnTitle || 'Status' @ i18n }</th>
+                            <th class="cmp-modal-downloads__col--total-count">${ properties.numberOfFilesColumnTitle || 'No. of files' @ i18n }</th>
+                            <th class="cmp-modal-downloads__col--file-size">${ properties.downloadSizeTitle || 'Download size' @ i18n }</th>
+                            <th class="cmp-modal-downloads__col--file-action"></th>
+                            <th class="cmp-modal-downloads__col--file-action"></th>
+                        </tr>
+                    </thead>
+                    <sly data-sly-list.download="${downloads.downloads}">
+                         <sly data-sly-call="${downloadTemplate.download @ download = download}"/>
+                    </sly>
+                </table>
+
+            </div>
+
+            <p data-sly-test="${!hasDownloads}"
+               class="cmp-modal-downloads__empty-text">${properties['emptyText'] || "No downloads pending" @ i18n}</p>
+        </div>
+        <div class="actions">
+            <div class="ui black deny button">
+                ${properties.closeButton || 'Close' @ i18n}
+            </div>
+            <div class="ui black button align left"
+                 data-sly-test="${hasDownloads}"
+                 data-asset-share-id="clear-downloads">
+                ${properties.clearButton || 'Clear Downloads' @ i18n}
+            </div>
+        </div>
+    </div>
 </sly>
 
-<div data-asset-share-id="downloads-modal"
-     data-asset-share-update-method="replace"
-     data-asset-share-update-when="downloads-updated"
-     data-asset-share-downloads-count="${downloads.downloads.size}"
-     class="ui long modal cmp-modal cmp-modal-downloads">
-    <i class="close icon"></i>
-
-    <div class="header">
-        ${properties.modalTitle || 'Downloads' @i18n}
-        <span data-sly-test="${hasDownloads}"
-                data-asset-share-id="refresh-downloads">
-                <a href="#refresh"><i class="cmp-modal-downloads__refresh sync alternate icon"></i></a>
-        </span>
-    </div>
-
-    <div class="scrolling content">
-
-        <div class="ui container">
-
-            <table class="cmp-modal-downloads__table"
-                   data-sly-test="${hasDownloads}">
-                <thead class="cmp-modal-downloads__table-header">
-                    <tr>
-                        <th class="cmp-modal-downloads__col--archive-name"></th>
-                        <th class="cmp-modal-downloads__col--file-status">${ properties.statusColumnTitle || 'Status' @ i18n }</th>
-                        <th class="cmp-modal-downloads__col--total-count">${ properties.numberOfFilesColumnTitle || 'No. of files' @ i18n }</th>
-                        <th class="cmp-modal-downloads__col--file-size">${ properties.downloadSizeTitle || 'Download size' @ i18n }</th>
-                        <th class="cmp-modal-downloads__col--file-action"></th>
-                        <th class="cmp-modal-downloads__col--file-action"></th>
-                    </tr>
-                </thead>
-                <sly data-sly-list.download="${downloads.downloads}">
-                     <sly data-sly-call="${downloadTemplate.download @ download = download}"/>
-                </sly>
-            </table>
-
-        </div>
-
-        <p data-sly-test="${!hasDownloads}"
-           class="cmp-modal-downloads__empty-text">${properties['emptyText'] || "No downloads pending" @ i18n}</p>
-    </div>
-    <div class="actions">
-        <div class="ui black deny button">
-            ${properties.closeButton || 'Close' @ i18n}
-        </div>
-        <div class="ui black button align left"
-             data-sly-test="${hasDownloads}"
-             data-asset-share-id="clear-downloads">
-            ${properties.clearButton || 'Clear Downloads' @ i18n}
-        </div>
-    </div>
-</div>
-
-
-
-
-
+<!--/* AEM Classic notice to authors */-->
+<sly data-sly-test="${config.aemClassic && !wccmode.disabled}">
+    <center>
+        <h2>Asset Share Commons' Downloads Modal only works on AEM as a Cloud Service.</h2>
+        <p>Please refrain from using this component on AEM 6.5.</p>
+    </center>
+</sly>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/page/init.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/page/init.html
@@ -25,11 +25,11 @@
        data-asset-share-id="share-url"
        value="${config.shareActionUrl}"/>
 <input type="hidden"
-       data-sly-test="${!config.aemClassic && (config.downloadEnabled || config.downloadEnabledCart)}"
+       data-sly-test="${config.downloadEnabled || config.downloadEnabledCart}"
        data-asset-share-id="download-url"
        value="${config.downloadActionUrl}"/>
 <input type="hidden"
-       data-sly-test="${config.downloadEnabled || config.downloadEnabledCart}"
+       data-sly-test="${!config.aemClassic && (config.downloadEnabled || config.downloadEnabledCart)}"
        data-asset-share-id="downloads-url"
        value="${config.downloadsActionUrl}"/>
 <input type="hidden"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/config.prod/org.apache.sling.commons.log.LogManager.factory.config-asset-share-commons.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/config.prod/org.apache.sling.commons.log.LogManager.factory.config-asset-share-commons.xml
@@ -5,4 +5,4 @@
           org.apache.sling.commons.log.level="$[env:ASC_LOG_LEVEL;default=error]"
           org.apache.sling.commons.log.names="[com.adobe.aem.commons.assetshare]"
           org.apache.sling.commons.log.additiv="true"
-          org.apache.sling.commons.log.pattern="${symbol_escape}{0,date,yyyy-MM-dd HH:mm:ss.SSS} {4} [{3}] {5}" />
+          org.apache.sling.commons.log.pattern="{0,date,yyyy-MM-dd HH:mm:ss.SSS} {4} [{3}] {5}" />

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/config.stage/org.apache.sling.commons.log.LogManager.factory.config-asset-share-commons.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/config.stage/org.apache.sling.commons.log.LogManager.factory.config-asset-share-commons.xml
@@ -5,4 +5,4 @@
           org.apache.sling.commons.log.level="$[env:ASC_LOG_LEVEL;default=warn]"
           org.apache.sling.commons.log.names="[com.adobe.aem.commons.assetshare]"
           org.apache.sling.commons.log.additiv="true"
-          org.apache.sling.commons.log.pattern="${symbol_escape}{0,date,yyyy-MM-dd HH:mm:ss.SSS} {4} [{3}] {5}" />
+          org.apache.sling.commons.log.pattern="{0,date,yyyy-MM-dd HH:mm:ss.SSS} {4} [{3}] {5}" />

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/config/org.apache.sling.commons.log.LogManager.factory.config-asset-share-commons.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/config/org.apache.sling.commons.log.LogManager.factory.config-asset-share-commons.xml
@@ -5,4 +5,4 @@
           org.apache.sling.commons.log.level="$[env:ASC_LOG_LEVEL;default=debug]"
           org.apache.sling.commons.log.names="[com.adobe.aem.commons.assetshare]"
           org.apache.sling.commons.log.additiv="true"
-          org.apache.sling.commons.log.pattern="${symbol_escape}{0,date,yyyy-MM-dd HH:mm:ss.SSS} {4} [{3}] {5}" />
+          org.apache.sling.commons.log.pattern="{0,date,yyyy-MM-dd HH:mm:ss.SSS} {4} [{3}] {5}" />

--- a/ui.frontend.theme.light/semanticui/site/collections/table.overrides
+++ b/ui.frontend.theme.light/semanticui/site/collections/table.overrides
@@ -21,7 +21,7 @@
       }
 
       td {
-        border-bottom: solid 1px @grey !important;
+        border-bottom: solid 1px #ccc !important;
         text-transform: uppercase;
 
         .lowercase {


### PR DESCRIPTION
* Removed ui.content.sample form all project
* Added a bunch of the Core Cmp v2 proxy components
* Some 6.x/Classic fixes
* Smoke-tested on 6.5.7 