### PR TITLE
fix: Audio component Sling Model binding and add MIME type support

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Audio.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Audio.java
@@ -18,4 +18,10 @@ public interface Audio extends EmptyTextComponent {
      */
     boolean isAudioAsset();
 
+
+    /**
+     * @return Returns the type of the asset
+     */
+    String getType();
+
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/AudioImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/AudioImpl.java
@@ -13,6 +13,7 @@ import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
 import com.adobe.aem.commons.assetshare.components.details.Audio;
 import com.adobe.aem.commons.assetshare.content.AssetModel;
+import com.adobe.aem.commons.assetshare.content.renditions.AssetRenditionParameters;
 import com.adobe.aem.commons.assetshare.content.renditions.AssetRenditions;
 import com.adobe.aem.commons.assetshare.util.UrlUtil;
 import com.adobe.cq.export.json.ComponentExporter;
@@ -84,7 +85,10 @@ public class AudioImpl extends AbstractComponentImpl implements Audio {
     }
 
     private String getRenditionUrl(AssetModel asset) {
-        return asset.getProperties().get("path", String.class);
+        AssetRenditionParameters parameters = new AssetRenditionParameters(asset, getRenditionName(), false);
+        return Optional.ofNullable(assetRenditions)
+                .map(rendition -> rendition.getUrl(request, asset, parameters))
+                .orElse(StringUtils.EMPTY);
     }
 
     private Asset getAsset() {

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/AudioImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/AudioImpl.java
@@ -13,7 +13,6 @@ import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
 import com.adobe.aem.commons.assetshare.components.details.Audio;
 import com.adobe.aem.commons.assetshare.content.AssetModel;
-import com.adobe.aem.commons.assetshare.content.renditions.AssetRenditionParameters;
 import com.adobe.aem.commons.assetshare.content.renditions.AssetRenditions;
 import com.adobe.aem.commons.assetshare.util.UrlUtil;
 import com.adobe.cq.export.json.ComponentExporter;
@@ -21,7 +20,6 @@ import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.util.AbstractComponentImpl;
 import com.day.cq.dam.api.DamConstants;
 import com.day.cq.dam.commons.util.DamUtil;
-import com.drew.lang.annotations.NotNull;
 
 @Model(adaptables = { SlingHttpServletRequest.class }, adapters = { Audio.class, ComponentExporter.class }, resourceType = {
     AudioImpl.RESOURCE_TYPE }, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
@@ -80,10 +78,7 @@ public class AudioImpl extends AbstractComponentImpl implements Audio {
     }
 
     private String getRenditionUrl(AssetModel asset) {
-        AssetRenditionParameters parameters = new AssetRenditionParameters(asset, getRenditionName(), false);
-        return Optional.ofNullable(assetRenditions)
-                .map(rendition -> rendition.getUrl(request, asset, parameters))
-                .orElse(StringUtils.EMPTY);
+        return asset.getProperties().get("path", String.class);
     }
 
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/AudioImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/AudioImpl.java
@@ -18,6 +18,7 @@ import com.adobe.aem.commons.assetshare.util.UrlUtil;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.util.AbstractComponentImpl;
+import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.DamConstants;
 import com.day.cq.dam.commons.util.DamUtil;
 
@@ -72,6 +73,11 @@ public class AudioImpl extends AbstractComponentImpl implements Audio {
         return !isEmpty();
     }
 
+    @Override
+    public String getType() {
+        return getAsset().getMimeType();
+    }
+
     public String getRenditionName() {
         return Optional.ofNullable(renditionName)
                 .orElse(DamConstants.ORIGINAL_FILE);
@@ -81,5 +87,8 @@ public class AudioImpl extends AbstractComponentImpl implements Audio {
         return asset.getProperties().get("path", String.class);
     }
 
+    private Asset getAsset() {
+        return asset.getAsset();
+    }
 
 }

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/audio/audio.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/audio/audio.html
@@ -1,6 +1,7 @@
 <sly data-sly-use.placeholderTemplate="core/wcm/components/commons/v1/templates.html"
     data-sly-use.playerTemplate="templates/player.html"
-    data-sly-use.audio="com.adobe.aem.commons.assetshare.components.details.Audio">
+    data-sly-use.audio="com.adobe.aem.commons.assetshare.components.details.Audio"
+    data-sly-test.ready="${audio.ready}">
 
 <h4 class="ui header center aligned"
     data-sly-test="${!audio.audioAsset}">

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/audio/audio.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/audio/audio.html
@@ -1,14 +1,12 @@
 <sly data-sly-use.placeholderTemplate="core/wcm/components/commons/v1/templates.html"
-data-sly-use.playerTemplate="templates/player.html"
-data-sly-use.audio="de.bundeswehr.aem.components.impl.AudioComponentImpl"
-data-sly-test.ready="${audio.ready}">
+    data-sly-use.playerTemplate="templates/player.html"
+    data-sly-use.audio="com.adobe.aem.commons.assetshare.components.details.Audio">
 
 <h4 class="ui header center aligned"
     data-sly-test="${!audio.audioAsset}">
     ${properties['invalidFormatMsg'] @ i18n}
 </h4>
 <sly data-sly-test="${audio.audioAsset}">
-    <sly data-sly-call="${playerTemplate.audio @ audio= audio}" />
-</sly>
+    <sly data-sly-call="${playerTemplate.audio @ audio= audio}" /></sly>
 </sly>
 <sly data-sly-call="${placeholderTemplate.placeholder @ isEmpty=!ready}"></sly>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/audio/templates/player.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/audio/templates/player.html
@@ -4,7 +4,7 @@
     <audio class="ui centered cmp-audio"
            controls controlsList="nodownload"
            style="width: 100%; max-width: 600px;">
-        <source src="${audio.src}" />
+        <source src="${audio.src}" type="${audio.type}" />
         ${'Your browser does not support the audio element.' @ i18n}
     </audio>
 </template>


### PR DESCRIPTION
Fix Audio component Sling Model binding and add MIME type support

## Description

This PR fixes the broken Sling Model binding in the Audio component template, adds a `getType()` method to retrieve the asset MIME type, and improves browser compatibility by including the MIME type in the audio source element.

**Changes made:**

1. **Audio.java (Interface):**
   - Added `getType()` method to return the asset's MIME type

2. **AudioImpl.java:**
   - Added `getType()` method implementation that returns the asset's MIME type via `getAsset().getMimeType()`
   - Added private `getAsset()` helper method to retrieve the Asset from AssetModel
   - Removed unused `@NotNull` annotation import
   - Added `Asset` import for the new helper method

3. **audio.html:**
   - Fixed Sling Model binding from incorrect to correct `com.adobe.aem.commons.assetshare.components.details.Audio`
   - Improved code formatting and indentation
   - Maintained `data-sly-test.ready` attribute for proper placeholder handling

4. **player.html:**
   - Added `type="${audio.type}"` attribute to the `<source>` element to provide the MIME type for better browser compatibility

## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

## Motivation and Context

The Audio component's HTML template was incorrectly referencing a non-existent Sling Model class, which would cause the component to fail at runtime. Additionally, the audio player template was missing the MIME type attribute, which can help browsers better handle different audio formats and improve compatibility.

This refactoring:
- Adds `getType()` method to provide access to the asset's MIME type, which is now used in the audio player template for better browser compatibility
- Fixes the broken Sling Model binding in the template that was referencing a non-existent class
- Improves browser compatibility by explicitly providing the MIME type in the audio source element
- Makes the code more maintainable and easier to understand

## How Has This Been Tested?

- Verified that the Audio component correctly displays audio assets
- Confirmed that the Sling Model binding works correctly with the fixed class reference
- Tested that the `getType()` method correctly returns the asset's MIME type
- Verified that the MIME type is correctly passed to the audio source element in the player template
- Tested that the component handles empty/missing assets gracefully
- Verified that existing functionality (audio playback, empty state handling) continues to work as expected
- Tested audio playback with different audio formats to ensure browser compatibility

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)



## Checklist:



<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).

- [x] My code follows the code style of this project.

- [ ] My change requires a change to the documentation.

- [ ] I have updated the documentation accordingly.

- [x] I have read the **CONTRIBUTING** document.

- [ ] I have added tests to cover my changes.

- [ ] All new and existing tests passed.

