### PR TITLE
Added Externalizer domain to Share configuration

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
@@ -226,7 +226,7 @@ public class EmailShareServiceImpl implements ShareService {
                     url = externalizer.authorLink(config.getResourceResolver(), url);
                 } else {
                     url = externalizer.externalLink(config.getResourceResolver(),
-                            config.getProperties().get(PN_EXTERNALIZER_DOMAIN, cfg.externalizerDomain()),
+                            externalizerDomain,
                             url);
                 }
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
@@ -95,6 +95,7 @@ public class EmailShareServiceImpl implements ShareService {
     /* Share properties */
     private static final String PN_TRACKING_NAME = "trackingName";
     private static final String PN_TRACKING_VALUE = "trackingValue";
+    private static final String PN_EXTERNALIZER_DOMAIN = "externalizerDomain";
 
     private transient Cfg cfg;
     private transient BundleContext bundleContext;
@@ -185,7 +186,9 @@ public class EmailShareServiceImpl implements ShareService {
         }
 
         // Generate the HTML list of Assets and their links
-        emailParameters.put(EMAIL_ASSET_LINK_LIST_HTML, getAssetLinkListHtml(config, assetPaths));
+        emailParameters.put(EMAIL_ASSET_LINK_LIST_HTML, getAssetLinkListHtml(config,
+                shareParameters.get(PN_EXTERNALIZER_DOMAIN, String.class),
+                assetPaths));
 
         // Send e-mail
         final List<String> failureList = emailService.sendEmail(emailTemplatePath, emailParameters, emailAddresses);
@@ -194,7 +197,9 @@ public class EmailShareServiceImpl implements ShareService {
         }
     }
 
-    private final String getAssetLinkListHtml(final Config config, final String[] assetPaths) {
+    private final String getAssetLinkListHtml(final Config config, String externalizerDomain, final String[] assetPaths) {
+        externalizerDomain = StringUtils.defaultIfBlank(externalizerDomain, cfg.externalizerDomain());
+
         final StringBuilder sb = new StringBuilder();
 
         for (final String assetPath : assetPaths) {
@@ -217,7 +222,9 @@ public class EmailShareServiceImpl implements ShareService {
                 if (RequireAem.ServiceType.AUTHOR.equals(requireAem.getServiceType())) {
                     url = externalizer.authorLink(config.getResourceResolver(), url);
                 } else {
-                    url = externalizer.externalLink(config.getResourceResolver(), cfg.externalizerDomain(), url);
+                    url = externalizer.externalLink(config.getResourceResolver(),
+                            config.getProperties().get(PN_EXTERNALIZER_DOMAIN, cfg.externalizerDomain()),
+                            url);
                 }
 
                 String trackingName = config.getProperties().get(PN_TRACKING_NAME, String.class);

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
@@ -153,10 +153,13 @@ public class EmailShareServiceImpl implements ShareService {
             shareParameters.put(EmailService.REPLY_TO, replyToAddress);
         }
 
-        share(request.adaptTo(Config.class), unprotectedShareParameters, shareParameters, StringUtils.defaultIfBlank(emailShare.getEmailTemplatePath(), cfg.emailTemplate()));
+        share(request.adaptTo(Config.class), emailShare, unprotectedShareParameters, shareParameters);
     }
 
-    private final void share(final Config config, final ValueMap unprotectedShareParameters, final ValueMap shareParameters, final String emailTemplatePath) throws ShareException {
+    private void share(final Config config, final EmailShare emailShare, final ValueMap unprotectedShareParameters, final ValueMap shareParameters) throws ShareException {
+
+        final String emailTemplatePath = StringUtils.defaultIfBlank(emailShare.getEmailTemplatePath(), cfg.emailTemplate());
+        final String externalizerDomain = StringUtils.defaultIfBlank(emailShare.getProperties().get(PN_EXTERNALIZER_DOMAIN, cfg.externalizerDomain()), "publish");
         final String[] emailAddresses = StringUtils.split(unprotectedShareParameters.get(EMAIL_ADDRESSES, ""), ",");
 
         final String[] assetPaths = Arrays.stream(unprotectedShareParameters.get(ASSET_PATHS, ArrayUtils.EMPTY_STRING_ARRAY))
@@ -187,7 +190,7 @@ public class EmailShareServiceImpl implements ShareService {
 
         // Generate the HTML list of Assets and their links
         emailParameters.put(EMAIL_ASSET_LINK_LIST_HTML, getAssetLinkListHtml(config,
-                shareParameters.get(PN_EXTERNALIZER_DOMAIN, String.class),
+                externalizerDomain,
                 assetPaths));
 
         // Send e-mail
@@ -271,7 +274,7 @@ public class EmailShareServiceImpl implements ShareService {
     }
 
     private String getReplyToAddress(final EmailShare emailShare, final UserProperties userProperties) throws ShareException {
-        boolean replyToSharer = emailShare.getProperties().get(EmailShare.PN_USE_SHARER_EMAIL_AS_REPLY_TO, false);
+            boolean replyToSharer = emailShare.getProperties().get(EmailShare.PN_USE_SHARER_EMAIL_AS_REPLY_TO, false);
         if (replyToSharer && userProperties != null) {
 
           try {

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/share/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/share/_cq_dialog/.content.xml
@@ -251,9 +251,9 @@
                                     <externalizer-domain
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                            fieldDescription="The domain-mapping key used to generate absolute URLs to assets in the e-mail template. Check with your AEM administrator for the correct value. If not set here, the OSGi-based global variable is used, which defaults to 'publish'."
+                                            fieldDescription="The domain-mapping key used to generate absolute URLs to AEM Publish, for assets in the e-mail template. Check with your AEM administrator for the correct value. If not set here, the OSGi-based global variable is used, which defaults to 'publish'."
                                             emptyText="publish"
-                                            fieldLabel="Externalizer Domain"
+                                            fieldLabel="AEM Publish Externalizer Domain"
                                             name="./externalizerDomain"
                                             required="{Boolean}false"/>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/share/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/share/_cq_dialog/.content.xml
@@ -247,6 +247,16 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 name="./allowedQueryParams"/>
                                     </allowed-query-params>
+
+                                    <externalizer-domain
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                            fieldDescription="The domain-mapping key used to generate absolute URLs to assets in the e-mail template. Check with your AEM administrator for the correct value. If not set here, the OSGi-based global variable is used, which defaults to 'publish'."
+                                            emptyText="publish"
+                                            fieldLabel="Externalizer Domain"
+                                            name="./externalizerDomain"
+                                            required="{Boolean}false"/>
+
                                 </items>
                             </column>
                         </items>


### PR DESCRIPTION
## Description

Added ability to the the externalizer domain key in the Share modal dialog.

This allows multiple ASC installs on the same AEM, to the share URLs to be served off different domains.

## Related Issue

Fixes https://github.com/adobe/asset-share-commons/issues/1319

## Motivation and Context

See https://github.com/adobe/asset-share-commons/issues/1319

## How Has This Been Tested?

Tested on AEM SDK.

## Screenshots (if appropriate):

<img width="863" height="1329" alt="2025-12-12 at 1 03 PM" src="https://github.com/user-attachments/assets/5213f65d-ad15-4659-ae1e-def0975bf12f" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
