### PR TITLE
Fix race condition in AiFulltextPredicateEvaluatorTest

### DIFF
--- a/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/AiFulltextPredicateEvaluatorTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/AiFulltextPredicateEvaluatorTest.java
@@ -1,8 +1,6 @@
 package com.adobe.aem.commons.assetshare.search.impl.predicateevaluators;
 
 import com.day.cq.search.Predicate;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -10,64 +8,66 @@ import static org.junit.Assert.*;
 public class AiFulltextPredicateEvaluatorTest {
     private static final Object LOCK = new Object();
 
-    @Before
-    public void setUp() throws Exception {
-    }
-
-
-    @After
-    public void tearDown() throws Exception {
-        System.clearProperty("oak.query.InferenceEnabled");
-    }
-
     @Test
     public void buildPredicate_enabled() {
         synchronized (LOCK) {
-            System.setProperty("oak.query.InferenceEnabled", "true");
+            try {
+                System.setProperty("oak.query.InferenceEnabled", "true");
 
-            AiFulltextPredicateEvaluator evaluator = new AiFulltextPredicateEvaluator();
-            Predicate predicate = new Predicate(AiFulltextPredicateEvaluator.PREDICATE_NAME);
-            predicate.set(AiFulltextPredicateEvaluator.PREDICATE_NAME, "test");
+                AiFulltextPredicateEvaluator evaluator = new AiFulltextPredicateEvaluator();
+                Predicate predicate = new Predicate(AiFulltextPredicateEvaluator.PREDICATE_NAME);
+                predicate.set(AiFulltextPredicateEvaluator.PREDICATE_NAME, "test");
 
-            Predicate builtPredicate = evaluator.buildPredicate(predicate);
+                Predicate builtPredicate = evaluator.buildPredicate(predicate);
 
-            assertEquals("?{}?test", builtPredicate.get("fulltext"));
-            assertNull(builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_NAME));
-            assertEquals(AiFulltextPredicateEvaluator.PREDICATE_BUILT_VALUE, builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_BUILT_KEY));
+                assertEquals("?{}?test", builtPredicate.get("fulltext"));
+                assertNull(builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_NAME));
+                assertEquals(AiFulltextPredicateEvaluator.PREDICATE_BUILT_VALUE, builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_BUILT_KEY));
+            } finally {
+                System.clearProperty("oak.query.InferenceEnabled");
+            }
         }
     }
 
     @Test
     public void buildPredicate_disabledNotSet() {
         synchronized (LOCK) {
-            System.clearProperty("oak.query.InferenceEnabled");
+            try {
+                System.clearProperty("oak.query.InferenceEnabled");
 
-            AiFulltextPredicateEvaluator evaluator = new AiFulltextPredicateEvaluator();
-            Predicate predicate = new Predicate(AiFulltextPredicateEvaluator.PREDICATE_NAME);
-            predicate.set(AiFulltextPredicateEvaluator.PREDICATE_NAME, "test");
+                AiFulltextPredicateEvaluator evaluator = new AiFulltextPredicateEvaluator();
+                Predicate predicate = new Predicate(AiFulltextPredicateEvaluator.PREDICATE_NAME);
+                predicate.set(AiFulltextPredicateEvaluator.PREDICATE_NAME, "test");
 
-            Predicate builtPredicate = evaluator.buildPredicate(predicate);
+                Predicate builtPredicate = evaluator.buildPredicate(predicate);
 
-            assertEquals("test", builtPredicate.get("fulltext"));
-            assertNull(builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_NAME));
-            assertEquals(AiFulltextPredicateEvaluator.PREDICATE_BUILT_VALUE, builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_BUILT_KEY));
+                assertEquals("test", builtPredicate.get("fulltext"));
+                assertNull(builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_NAME));
+                assertEquals(AiFulltextPredicateEvaluator.PREDICATE_BUILT_VALUE, builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_BUILT_KEY));
+            } finally {
+                System.clearProperty("oak.query.InferenceEnabled");
+            }
         }
     }
 
     @Test
     public void buildPredicate_disabledFalse() {
         synchronized (LOCK) {
-            System.setProperty("oak.query.InferenceEnabled", "false");
+            try {
+                System.setProperty("oak.query.InferenceEnabled", "false");
 
-            AiFulltextPredicateEvaluator evaluator = new AiFulltextPredicateEvaluator();
-            Predicate predicate = new Predicate(AiFulltextPredicateEvaluator.PREDICATE_NAME);
-            predicate.set(AiFulltextPredicateEvaluator.PREDICATE_NAME, "test");
+                AiFulltextPredicateEvaluator evaluator = new AiFulltextPredicateEvaluator();
+                Predicate predicate = new Predicate(AiFulltextPredicateEvaluator.PREDICATE_NAME);
+                predicate.set(AiFulltextPredicateEvaluator.PREDICATE_NAME, "test");
 
-            Predicate builtPredicate = evaluator.buildPredicate(predicate);
+                Predicate builtPredicate = evaluator.buildPredicate(predicate);
 
-            assertEquals("test", builtPredicate.get("fulltext"));
-            assertNull(builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_NAME));
-            assertEquals(AiFulltextPredicateEvaluator.PREDICATE_BUILT_VALUE, builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_BUILT_KEY));
+                assertEquals("test", builtPredicate.get("fulltext"));
+                assertNull(builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_NAME));
+                assertEquals(AiFulltextPredicateEvaluator.PREDICATE_BUILT_VALUE, builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_BUILT_KEY));
+            } finally {
+                System.clearProperty("oak.query.InferenceEnabled");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix intermittent test failure in `AiFulltextPredicateEvaluatorTest.buildPredicate_enabled` caused by a race condition under parallel test execution
- The `@After tearDown()` cleared `oak.query.InferenceEnabled` system property **outside** the `synchronized(LOCK)` block, allowing concurrent test methods to interfere with each other
- Moved system property cleanup into `try/finally` blocks inside each synchronized block so the property is never modified outside the lock

## Test plan
- [x] `mvn test -pl core` — all 254 tests pass (previously 1 failure)
- [x] Verified the fix resolves the flaky `buildPredicate_enabled` test that failed with: `expected:<[?{}?]test> but was:<[]test>`